### PR TITLE
Improved field flow

### DIFF
--- a/packages/common/dist/custom-methods.js
+++ b/packages/common/dist/custom-methods.js
@@ -379,7 +379,7 @@ export const watchInmemField = () => {
 };
 // @TODO Refactor (low priority)
 export const watchGiveBySelectField = () => {
-    const enFieldGiveBySelect = document.querySelector(".en__field--giveBySelect");
+    const enFieldGiveBySelect = document.querySelector(".en__field--give-by-select");
     const transactionGiveBySelect = document.getElementsByName("transaction.giveBySelect");
     const enFieldPaymentType = document.querySelector("#en__field_transaction_paymenttype");
     let enFieldGiveBySelectCurrentValue = document.querySelector('input[name="transaction.giveBySelect"]:checked');

--- a/packages/common/src/custom-methods.ts
+++ b/packages/common/src/custom-methods.ts
@@ -412,7 +412,7 @@ export const watchInmemField = () => {
 // @TODO Refactor (low priority)
 export const watchGiveBySelectField = () => {
   const enFieldGiveBySelect = document.querySelector(
-    ".en__field--giveBySelect"
+    ".en__field--give-by-select"
   ) as HTMLElement;
   const transactionGiveBySelect = document.getElementsByName(
     "transaction.giveBySelect"

--- a/packages/styles/dist/main.css
+++ b/packages/styles/dist/main.css
@@ -2076,7 +2076,8 @@ label a.label-tooltip {
   right: 0;
   text-decoration: underline;
   color: var(--label-color);
-  font-weight: 400; }
+  font-weight: 400;
+  padding-right: 0.5rem; }
 
 input,
 input.en__field__input {
@@ -2326,6 +2327,10 @@ textarea,
     border-color: var(--textarea_border-color_hover);
     border-bottom-color: var(--textarea_border-bottom-color_hover);
     box-shadow: var(--textarea_box-shadow_hover); }
+  textarea.en__field,
+  .en__contactMessage__plainText.en__field {
+    margin-left: 0;
+    margin-right: 0; }
 
 .en__field__item {
   padding: initial; }
@@ -2363,7 +2368,6 @@ textarea,
 .en__hidden {
   display: none !important; }
 
-.en__field,
 .en__captcha {
   padding-bottom: 0;
   margin-bottom: 1rem;
@@ -2388,16 +2392,6 @@ textarea,
 
 /* If the form field has a hidden "other" field we need to remove the end of row spacing */
 /* NEED TO REVISIT FOR CODE CLEANUP */
-.en__component--formblock
-.en__field--withOther
-div.en__field__item:nth-last-child(2) {
-  margin-right: 0px; }
-
-.en__component--formblock .row-wrap .en__field,
-.en__component--formblock .row-wrap .en__field div.en__field__item {
-  margin-left: 0.5rem;
-  margin-right: 0.5rem; }
-
 /************************************
 * Inputs
 ***********************************/
@@ -2485,7 +2479,7 @@ input.en__contactDetails__select {
 .en__field__input--checkbox:focus + .en__field__label,
 .en__contactDetails__select:focus + .en__contactDetails__rows {
   outline: -webkit-focus-ring-color auto 1px;
-  outline-offset: 3px; }
+  outline-offset: calc(0.5rem - 3px); }
 
 /* QA Needed: EN's hidden input field */
 .en__field--hidden {
@@ -2497,62 +2491,79 @@ input.en__contactDetails__select {
 /* Should confirm if the EN class field could even hold enough chars to fit defining 20 fields plus their start/stop classes */
 /* Why 20 pre-defined options? To cover a single form component with all of the following: * 1. First Name (50%) | 2. Last Name (50%) * 3. Email (100%) * 4. Email Opt-in (100%) * 5. Phone (100%) * 6. Phone Opt-in (100%) * 7. Street (100%) * 8. Street 2 (100%) * 9. City (33%) | 10. State (33%) | 11. Zip (33%) * 12. Country (100%) * 13. Giving Frequency (100%) * 14. Giving Amount (100%) * 15. Gift Type (100%) * 16. Credit Card Number (100%) * 17. Credit Card Expiration (50%) | 18. Credit Card CVV (50%) * 19. Custom Field (100%) * 20. Custom Field (100%) */
 /* Make all en fields 100% */
-.en__field {
-  flex-basis: 100%;
-  padding-bottom: 1rem;
-  margin-bottom: 0rem; }
-
-/* All Single Fields that do not Wrap */
-.en__field--survey,
-.en__field--number,
-.en__field--calendar,
-.en__field--select,
-.en__field--text,
-.en__field--telephone,
-.en__field--range,
-.en__field--password,
-.en__field--calendar {
-  flex-basis: 100%;
-  padding-left: 0;
-  padding-right: 0; }
-
-.en__field--checkbox,
-.en__field--radio,
-.en__field--rating,
-.en__field--imgselect,
-.en__field--splittext,
-.en__field--tripletext,
-.en__field--splitselect,
-.en__field--tripleselect,
-.en__field--withOther {
-  flex-basis: calc(100% + 1rem);
+.en__component--formblock,
+.en__component--svblock {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-start;
   margin-left: -0.5rem;
   margin-right: -0.5rem; }
-  .en__field--checkbox > .en__field__label,
-  .en__field--checkbox > .en__field__helpText,
-  .en__field--radio > .en__field__label,
-  .en__field--radio > .en__field__helpText,
-  .en__field--rating > .en__field__label,
-  .en__field--rating > .en__field__helpText,
-  .en__field--imgselect > .en__field__label,
-  .en__field--imgselect > .en__field__helpText,
-  .en__field--splittext > .en__field__label,
-  .en__field--splittext > .en__field__helpText,
-  .en__field--tripletext > .en__field__label,
-  .en__field--tripletext > .en__field__helpText,
-  .en__field--splitselect > .en__field__label,
-  .en__field--splitselect > .en__field__helpText,
-  .en__field--tripleselect > .en__field__label,
-  .en__field--tripleselect > .en__field__helpText,
-  .en__field--withOther > .en__field__label,
-  .en__field--withOther > .en__field__helpText {
+  .en__component--formblock > *,
+  .en__component--svblock > * {
     padding-left: 0.5rem;
     padding-right: 0.5rem; }
+  .en__component--formblock .en__field,
+  .en__component--svblock .en__field {
+    display: flex;
+    flex-direction: column;
+    flex-basis: 100%;
+    padding-bottom: 0rem;
+    margin-bottom: 0.5rem; }
+    .en__component--formblock .en__field .en__field__element .en__field__label,
+    .en__component--formblock .en__field .en__field__element .en__field__helpText,
+    .en__component--svblock .en__field .en__field__element .en__field__label,
+    .en__component--svblock .en__field .en__field__element .en__field__helpText {
+      padding-top: 0.5rem;
+      padding-right: 0rem;
+      padding-bottom: 0.25rem;
+      padding-left: 0rem; }
+    .en__component--formblock .en__field .en__field__element > *:only-of-type,
+    .en__component--formblock .en__field .en__field__element .en__submit,
+    .en__component--svblock .en__field .en__field__element > *:only-of-type,
+    .en__component--svblock .en__field .en__field__element .en__submit {
+      padding-left: 0.5rem;
+      padding-right: 0.5rem;
+      margin-bottom: 0.5rem; }
+      .en__component--formblock .en__field .en__field__element > *:only-of-type.en__rangeFieldLabels,
+      .en__component--formblock .en__field .en__field__element .en__submit.en__rangeFieldLabels,
+      .en__component--svblock .en__field .en__field__element > *:only-of-type.en__rangeFieldLabels,
+      .en__component--svblock .en__field .en__field__element .en__submit.en__rangeFieldLabels {
+        padding-left: 0;
+        padding-right: 0; }
+    .en__component--formblock .en__field .en__field__element.en__field__element--checkbox, .en__component--formblock .en__field .en__field__element.en__field__element--radio, .en__component--formblock .en__field .en__field__element.en__field__element--rating, .en__component--formblock .en__field .en__field__element.en__field__element--imgselect, .en__component--formblock .en__field .en__field__element.en__field__element--splittext, .en__component--formblock .en__field .en__field__element.en__field__element--tripletext, .en__component--formblock .en__field .en__field__element.en__field__element--splitselect, .en__component--formblock .en__field .en__field__element.en__field__element--tripleselect, .en__component--formblock .en__field .en__field__element.en__field__element--withOther,
+    .en__component--svblock .en__field .en__field__element.en__field__element--checkbox,
+    .en__component--svblock .en__field .en__field__element.en__field__element--radio,
+    .en__component--svblock .en__field .en__field__element.en__field__element--rating,
+    .en__component--svblock .en__field .en__field__element.en__field__element--imgselect,
+    .en__component--svblock .en__field .en__field__element.en__field__element--splittext,
+    .en__component--svblock .en__field .en__field__element.en__field__element--tripletext,
+    .en__component--svblock .en__field .en__field__element.en__field__element--splitselect,
+    .en__component--svblock .en__field .en__field__element.en__field__element--tripleselect,
+    .en__component--svblock .en__field .en__field__element.en__field__element--withOther {
+      margin-left: -0.5rem;
+      margin-right: -0.5rem; }
+      .en__component--formblock .en__field .en__field__element.en__field__element--checkbox .en__field__item, .en__component--formblock .en__field .en__field__element.en__field__element--radio .en__field__item, .en__component--formblock .en__field .en__field__element.en__field__element--rating .en__field__item, .en__component--formblock .en__field .en__field__element.en__field__element--imgselect .en__field__item, .en__component--formblock .en__field .en__field__element.en__field__element--splittext .en__field__item, .en__component--formblock .en__field .en__field__element.en__field__element--tripletext .en__field__item, .en__component--formblock .en__field .en__field__element.en__field__element--splitselect .en__field__item, .en__component--formblock .en__field .en__field__element.en__field__element--tripleselect .en__field__item, .en__component--formblock .en__field .en__field__element.en__field__element--withOther .en__field__item,
+      .en__component--svblock .en__field .en__field__element.en__field__element--checkbox .en__field__item,
+      .en__component--svblock .en__field .en__field__element.en__field__element--radio .en__field__item,
+      .en__component--svblock .en__field .en__field__element.en__field__element--rating .en__field__item,
+      .en__component--svblock .en__field .en__field__element.en__field__element--imgselect .en__field__item,
+      .en__component--svblock .en__field .en__field__element.en__field__element--splittext .en__field__item,
+      .en__component--svblock .en__field .en__field__element.en__field__element--tripletext .en__field__item,
+      .en__component--svblock .en__field .en__field__element.en__field__element--splitselect .en__field__item,
+      .en__component--svblock .en__field .en__field__element.en__field__element--tripleselect .en__field__item,
+      .en__component--svblock .en__field .en__field__element.en__field__element--withOther .en__field__item {
+        padding-left: 0.5rem;
+        padding-right: 0.5rem; }
+    .en__component--formblock .en__field.en__field--withOther .en__field__element,
+    .en__component--svblock .en__field.en__field--withOther .en__field__element {
+      margin-left: -0.5rem;
+      margin-right: -0.5rem; }
+      .en__component--formblock .en__field.en__field--withOther .en__field__element .en__field__item,
+      .en__component--svblock .en__field.en__field--withOther .en__field__element .en__field__item {
+        padding-left: 0.5rem;
+        padding-right: 0.5rem; }
 
-.en__field__item {
-  padding-left: 0.5rem;
-  padding-right: 0.5rem; }
-
+/* All Single Fields that do not Wrap */
 .en__field__element--splittext,
 .en__field__element--splitselect,
 .en__field__element--tripleselect {
@@ -2616,9 +2627,6 @@ input.en__contactDetails__select {
 .en__imageSelectField__image {
   padding-bottom: 0.5rem; }
 
-.en__field--withOther .en__field__element--select .en__field__item:first-child {
-  margin-right: 0 !important; }
-
 /* Custom Styles */
 .inline-country .en__field--country {
   position: absolute;
@@ -2662,12 +2670,6 @@ input[type="number"]::-webkit-outer-spin-button {
 /* Microsoft Edge */
 ::-ms-input-placeholder {
   color: var(--color_light-gray); }
-
-/* Default Stylings for Common Form Fields */
-.en__component--formblock {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center; }
 
 /* ENGRID STYLINGS */
 @supports (-webkit-appearance: -apple-pay-button) {
@@ -3157,9 +3159,7 @@ body:not(#en__pagebuilder) .en__component--column:last-of-type,
 .i9-20 .en__field:nth-of-type(9),
 .i10-20 .en__field:nth-of-type(10),
 .i11-20 .en__field:nth-of-type(11) {
-  flex-basis: 20%;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem; }
+  flex-basis: 20%; }
 
 .i1-25 .en__field:nth-of-type(1),
 .i2-25 .en__field:nth-of-type(2),
@@ -3172,9 +3172,7 @@ body:not(#en__pagebuilder) .en__component--column:last-of-type,
 .i9-25 .en__field:nth-of-type(9),
 .i10-25 .en__field:nth-of-type(10),
 .i11-25 .en__field:nth-of-type(11) {
-  flex-basis: 25%;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem; }
+  flex-basis: 25%; }
 
 .i1-33 .en__field:nth-of-type(1),
 .i2-33 .en__field:nth-of-type(2),
@@ -3187,9 +3185,7 @@ body:not(#en__pagebuilder) .en__component--column:last-of-type,
 .i9-33 .en__field:nth-of-type(9),
 .i10-33 .en__field:nth-of-type(10),
 .i11-33 .en__field:nth-of-type(11) {
-  flex-basis: 33.33333%;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem; }
+  flex-basis: 33.33333%; }
 
 .i1-40 .en__field:nth-of-type(1),
 .i2-40 .en__field:nth-of-type(2),
@@ -3202,9 +3198,7 @@ body:not(#en__pagebuilder) .en__component--column:last-of-type,
 .i9-40 .en__field:nth-of-type(9),
 .i10-40 .en__field:nth-of-type(10),
 .i11-40 .en__field:nth-of-type(11) {
-  flex-basis: 40%;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem; }
+  flex-basis: 40%; }
 
 .i1-50 .en__field:nth-of-type(1),
 .i2-50 .en__field:nth-of-type(2),
@@ -3217,9 +3211,7 @@ body:not(#en__pagebuilder) .en__component--column:last-of-type,
 .i9-50 .en__field:nth-of-type(9),
 .i10-50 .en__field:nth-of-type(10),
 .i11-50 .en__field:nth-of-type(11) {
-  flex-basis: 50%;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem; }
+  flex-basis: 50%; }
 
 .i1-66 .en__field:nth-of-type(1),
 .i2-66 .en__field:nth-of-type(2),
@@ -3232,9 +3224,7 @@ body:not(#en__pagebuilder) .en__component--column:last-of-type,
 .i9-66 .en__field:nth-of-type(9),
 .i10-66 .en__field:nth-of-type(10),
 .i11-66 .en__field:nth-of-type(11) {
-  flex-basis: 66.66666%;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem; }
+  flex-basis: 66.66666%; }
 
 .i1-75 .en__field:nth-of-type(1),
 .i2-75 .en__field:nth-of-type(2),
@@ -3247,38 +3237,10 @@ body:not(#en__pagebuilder) .en__component--column:last-of-type,
 .i9-75 .en__field:nth-of-type(9),
 .i10-75 .en__field:nth-of-type(10),
 .i11-75 .en__field:nth-of-type(11) {
-  flex-basis: 75%;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem; }
+  flex-basis: 75%; }
 
 /* For items at the start of a row, remove left padding */
-.i1-start .en__field:nth-of-type(1),
-.i2-start .en__field:nth-of-type(2),
-.i3-start .en__field:nth-of-type(3),
-.i4-start .en__field:nth-of-type(4),
-.i5-start .en__field:nth-of-type(5),
-.i6-start .en__field:nth-of-type(6),
-.i7-start .en__field:nth-of-type(7),
-.i8-start .en__field:nth-of-type(8),
-.i9-start .en__field:nth-of-type(9),
-.i10-start .en__field:nth-of-type(10),
-.i11-start .en__field:nth-of-type(11) {
-  padding-left: 0; }
-
 /* For items at the end of a row, remove right padding */
-.i1-end .en__field:nth-of-type(1),
-.i2-end .en__field:nth-of-type(2),
-.i3-end .en__field:nth-of-type(3),
-.i4-end .en__field:nth-of-type(4),
-.i5-end .en__field:nth-of-type(5),
-.i6-end .en__field:nth-of-type(6),
-.i7-end .en__field:nth-of-type(7),
-.i8-end .en__field:nth-of-type(8),
-.i9-end .en__field:nth-of-type(9),
-.i10-end .en__field:nth-of-type(10),
-.i11-end .en__field:nth-of-type(11) {
-  padding-right: 0; }
-
 .i1-center .en__field:nth-of-type(1),
 .i2-center .en__field:nth-of-type(2),
 .i3-center .en__field:nth-of-type(3),
@@ -3431,9 +3393,7 @@ body:not(#en__pagebuilder) .i11-hide-label .en__field:nth-of-type(11) > label {
   .i9-m50 .en__field:nth-of-type(9),
   .i10-m50 .en__field:nth-of-type(10),
   .i11-m50 .en__field:nth-of-type(11) {
-    flex-basis: 50%;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem; }
+    flex-basis: 50%; }
   /* For items at the start of a row, remove left padding */
   .i1-mstart .en__field:nth-of-type(1),
   .i2-mstart .en__field:nth-of-type(2),
@@ -3446,7 +3406,8 @@ body:not(#en__pagebuilder) .i11-hide-label .en__field:nth-of-type(11) > label {
   .i9-mstart .en__field:nth-of-type(9),
   .i10-mstart .en__field:nth-of-type(10),
   .i11-mstart .en__field:nth-of-type(11) {
-    padding-left: 0; }
+    padding-left: 0;
+    margin-right: 0; }
   /* For items at the end of a row, remove right padding */
   .i1-mend .en__field:nth-of-type(1),
   .i2-mend .en__field:nth-of-type(2),
@@ -3459,21 +3420,8 @@ body:not(#en__pagebuilder) .i11-hide-label .en__field:nth-of-type(11) > label {
   .i9-mend .en__field:nth-of-type(9),
   .i10-mend .en__field:nth-of-type(10),
   .i11-mend .en__field:nth-of-type(11) {
-    padding-right: 0; }
-  .i1-m100 .en__field:nth-of-type(1),
-  .i2-m100 .en__field:nth-of-type(2),
-  .i3-m100 .en__field:nth-of-type(3),
-  .i4-m100 .en__field:nth-of-type(4),
-  .i5-m100 .en__field:nth-of-type(5),
-  .i6-m100 .en__field:nth-of-type(6),
-  .i7-m100 .en__field:nth-of-type(7),
-  .i8-m100 .en__field:nth-of-type(8),
-  .i9-m100 .en__field:nth-of-type(9),
-  .i10-m100 .en__field:nth-of-type(10),
-  .i11-m100 .en__field:nth-of-type(11) {
-    flex-basis: 100%;
-    padding-left: 0rem;
-    padding-right: 0rem; } }
+    padding-right: 0;
+    margin-left: 0; } }
 
 [data-engrid-theme] {
   --color_cta: var(--color_primary);
@@ -3512,22 +3460,10 @@ body:not(#en__pagebuilder) .i11-hide-label .en__field:nth-of-type(11) > label {
   --give-by-select__button_count: 4;
   --radio-to-buttons__button_count: 4; }
 
-.en__field--splitselect.en__field--ccexpire {
-  flex-basis: calc((100% / 3) * 2);
-  min-width: auto;
-  position: relative;
-  left: -0.5rem; }
-
-.en__field--ccvv {
-  flex-basis: calc(100% / 3);
-  min-width: auto;
-  position: relative;
-  right: -0.5rem; }
-
 .en__field--recurrfreq .en__field__element,
 .en__field--recurrpay .en__field__element,
 .en__field--donationAmt .en__field__element,
-.en__field--giveBySelect .en__field__element {
+.en__field--give-by-select .en__field__element {
   justify-content: center; }
 
 .en__field--donationAmt.en__field--withOther
@@ -3542,13 +3478,13 @@ body:not(#en__pagebuilder) .i11-hide-label .en__field:nth-of-type(11) > label {
 
 /* prettier-ignore */
 .radio-to-buttons .en__field--radio .en__field__input--radio + .en__field__label:before,
-.en__field--giveBySelect.en__field--radio .en__field__input--radio + .en__field__label:before,
+.en__field--give-by-select.en__field--radio .en__field__input--radio + .en__field__label:before,
 .radio-to-buttons_donationAmt .en__field--donationAmt.en__field--radio .en__field__input--radio + .en__field__label:before,
 .radio-to-buttons_recurrfreq .en__field--recurrfreq.en__field--radio .en__field__input--radio + .en__field__label:before {
   display: none; }
 
 .radio-to-buttons > .en__field > .en__field__element > .en__field__item:not(.en__field__item--other),
-.en__field--giveBySelect > .en__field__element .en__field__item:not(.en__field__item--other),
+.en__field--give-by-select > .en__field__element .en__field__item:not(.en__field__item--other),
 .radio-to-buttons_donationAmt > .en__field > .en__field__element .en__field__item:not(.en__field__item--other),
 .radio-to-buttons_recurrfreq > .en__field > .en__field__element .en__field__item:not(.en__field__item--other) {
   padding-left: 0;
@@ -3557,7 +3493,7 @@ body:not(#en__pagebuilder) .i11-hide-label .en__field:nth-of-type(11) > label {
   flex-shrink: 1; }
 
 .radio-to-buttons > .en__field > .en__field__element > .en__field__item--other,
-.en__field--giveBySelect > .en__field__element .en__field__item--other,
+.en__field--give-by-select > .en__field__element .en__field__item--other,
 .radio-to-buttons_donationAmt > .en__field > .en__field__element .en__field__item--other,
 .radio-to-buttons_recurrfreq > .en__field > .en__field__element .en__field__item--other {
   padding-left: .5rem;
@@ -3568,7 +3504,7 @@ body:not(#en__pagebuilder) .i11-hide-label .en__field:nth-of-type(11) > label {
 .radio-to-buttons > .en__field > .en__field__element > .en__field__input--other {
   border-radius: var(--button_border-radius); }
 
-.en__field--giveBySelect > .en__field__element .en__field__input--other {
+.en__field--give-by-select > .en__field__element .en__field__input--other {
   border-radius: var(--give-by-select__button_border-radius); }
 
 .radio-to-buttons_donationAmt > .en__field > .en__field__element .en__field__input--other {
@@ -3621,7 +3557,7 @@ body:not(#en__pagebuilder) .i11-hide-label .en__field:nth-of-type(11) > label {
   --radio-to-buttons__button_count: 5; }
 
 /* prettier-ignore */
-.en__field--giveBySelect.en__field--radio input[type=radio] + label {
+.en__field--give-by-select.en__field--radio input[type=radio] + label {
   font-family: var(--give-by-select__button_font-family);
   color: var(--give-by-select__button_color);
   font-size: var(--give-by-select__button_font-size);
@@ -3640,7 +3576,7 @@ body:not(#en__pagebuilder) .i11-hide-label .en__field:nth-of-type(11) > label {
   text-align: center;
   justify-content: center; }
 
-.en__field--giveBySelect > .en__field__element .en__field__item {
+.en__field--give-by-select > .en__field__element .en__field__item {
   flex-basis: calc(100% / var(--give-by-select__button_count)); }
 
 .give-by-select_count_1 {
@@ -3746,7 +3682,7 @@ body:not(#en__pagebuilder) .i11-hide-label .en__field:nth-of-type(11) > label {
   border-color: var(--button_border-color_hover); }
 
 /* prettier-ignore */
-.en__field--giveBySelect.en__field--radio .en__field__item:hover input[type=radio] + label {
+.en__field--give-by-select.en__field--radio .en__field__item:hover input[type=radio] + label {
   color: var(--give-by-select__button_color_hover);
   background-color: var(--give-by-select__button_background-color_hover);
   border-color: var(--give-by-select__button_border-color_hover); }
@@ -3775,7 +3711,7 @@ body:not(#en__pagebuilder) .i11-hide-label .en__field:nth-of-type(11) > label {
   border-color: var(--button_border-color_checked); }
 
 /* prettier-ignore */
-.en__field--giveBySelect.en__field--radio .en__field__item input[type=radio]:checked + label {
+.en__field--give-by-select.en__field--radio .en__field__item input[type=radio]:checked + label {
   color: var(--give-by-select__button_color_checked);
   background-color: var(--give-by-select__button_background-color_checked);
   border-color: var(--give-by-select__button_border-color_checked); }
@@ -3803,7 +3739,7 @@ body:not(#en__pagebuilder) .i11-hide-label .en__field:nth-of-type(11) > label {
   border-color: var(--button_border-color_checked); }
 
 /* prettier-ignore */
-.en__field--giveBySelect.en__field--radio .en__field__item:hover input[type=radio]:checked + label {
+.en__field--give-by-select.en__field--radio .en__field__item:hover input[type=radio]:checked + label {
   color: var(--give-by-select__button_color_checked);
   background-color: var(--give-by-select__button_background-color_checked);
   border-color: var(--give-by-select__button_border-color_checked); }
@@ -4028,18 +3964,6 @@ button.en__ecarditems__prevclose {
   font-size: 0.75rem;
   order: 3; }
 
-.en__field--splittext .en__field__error,
-.en__field--tripletext .en__field__error,
-.en__field--splitselect .en__field__error,
-.en__field--tripleselect .en__field__error,
-.en__field--radio .en__field__error,
-.en__field--checkbox .en__field__error,
-.en__field--rating .en__field__error,
-.en__field--imgselect .en__field__error,
-.en__field--withOther .en__field__error {
-  padding-left: 0.5rem;
-  padding-right: 0.5rem; }
-
 /* @TODO Not working anymore since we removed our corresponding JS */
 /* When EN's field validator flags an error it jumps the user to the first error on thepage. Our custom error JS executes after EN's and sets a body level class that we can reorder the field presentation on. If we don't wait to re-order the fields, the page will jump to the error which appears below the input resulting in the user having to scroll up to make the change. This is something that should be fixed on EN's end and how they handle errors, but until then we need this work around */
 /* Code dependent on "oc-en-error-helpers.js" which must execute after EN's "pagedata.js" */
@@ -4079,8 +4003,8 @@ body.error-jump-assist .en__component .en__field__error {
   border: var(--error__border-width) solid var(--error__color);
   background-color: var(--error__color_faded);
   padding-top: 0.5rem;
-  margin-left: 0.5rem;
-  margin-right: 0.5rem;
+  margin-left: 0rem;
+  margin-right: 0rem;
   border-radius: var(--input_border-radius); }
 
 .en__field--text.en__field--validationFailed .en__field__error,
@@ -6469,3 +6393,62 @@ body:not(#en__pagebuilder)[data-engrid-layout="centerright1col"] .page-backgroun
     #EN__RootElement .pboAdvancedRow__preview .hide.pboAdvancedRow__preview .en__component--column {
       outline-color: #ff0000 !important;
       z-index: 1; }
+
+/*
+* ##########################################################
+* # Page Builder Visual Changes for Editing Restricted Library Components
+* .edit-warning - https://d.pr/i/11bENF
+* .edit-lock - https://d.pr/i/vsA4ao
+* ##########################################################
+*/
+/* Make the border of componetn with an edit warning, red  */
+#en__pagebuilder .edit-warning.en__component.en__component--active.en__component--activeTarget {
+  box-shadow: 0 0 0 2px #f12222; }
+
+/* Make the border of component with an edit lock, black  */
+#en__pagebuilder .edit-lock.en__component.en__component--active.en__component--activeTarget {
+  box-shadow: 0 0 0 2px #000000; }
+
+/* Remove action handle from its normal position */
+/* Style the edit warning and lock messages to match the styling of the component actions */
+#en__pagebuilder .edit-warning.en__component.en__component--active.en__component--activeTarget .en__component__actions::after,
+#en__pagebuilder .edit-lock.en__component.en__component--active.en__component--activeTarget .en__component__actions::after {
+  display: block;
+  text-decoration: none;
+  line-height: 30px;
+  font-weight: 700;
+  padding: 0 6px 0 28px;
+  min-width: 30px;
+  text-align: left;
+  z-index: 9999;
+  white-space: nowrap; }
+
+/* Style edit warning messages to match the styling of the component actions */
+#en__pagebuilder .edit-warning.en__component.en__component--active.en__component--activeTarget .en__component__actions {
+  background-color: #f12222;
+  color: #fff; }
+
+/* Style the edit lock messages to match the styling of the component actions */
+#en__pagebuilder .edit-lock.en__component.en__component--active.en__component--activeTarget .en__component__actions {
+  background-color: #000000;
+  color: #fff; }
+
+/* Add edit warning message */
+#en__pagebuilder .edit-warning.en__component.en__component--active.en__component--activeTarget .en__component__actions::after {
+  content: "Unlink Before Editing"; }
+
+/* Add edit lock message */
+#en__pagebuilder .edit-lock.en__component.en__component--active.en__component--activeTarget .en__component__actions::after {
+  content: "Edit From Library"; }
+
+/* Hide the edit action when editing of the form component has been locked */
+#en__pagebuilder .edit-lock.en__component.en__component--active.en__component--activeTarget > .en__component__actions > a.en__component__action.en__component__action--settings {
+  display: none; }
+
+/* Change the background color of the component actions, when an edit warning is added, to further visually differentiate them */
+#en__pagebuilder .edit-warning.en__component.en__component--active.en__component--activeTarget > .en__component__actions > a.en__component__action {
+  background-color: #f12222; }
+
+/* Change the background color of the component actions, when an edit warning is added, to further visually differentiate them */
+#en__pagebuilder .edit-lock.en__component.en__component--active.en__component--activeTarget > .en__component__actions > a.en__component__action {
+  background-color: #000000; }

--- a/packages/styles/src/_engrid-components-layout.scss
+++ b/packages/styles/src/_engrid-components-layout.scss
@@ -11,8 +11,8 @@
 .i10-20 .en__field:nth-of-type(10),
 .i11-20 .en__field:nth-of-type(11) {
   flex-basis: 20%;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+  // padding-left: 0.5rem;
+  // padding-right: 0.5rem;
 }
 
 .i1-25 .en__field:nth-of-type(1),
@@ -27,8 +27,8 @@
 .i10-25 .en__field:nth-of-type(10),
 .i11-25 .en__field:nth-of-type(11) {
   flex-basis: 25%;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+  // padding-left: 0.5rem;
+  // padding-right: 0.5rem;
 }
 
 .i1-33 .en__field:nth-of-type(1),
@@ -43,8 +43,8 @@
 .i10-33 .en__field:nth-of-type(10),
 .i11-33 .en__field:nth-of-type(11) {
   flex-basis: 33.33333%;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+  // padding-left: 0.5rem;
+  // padding-right: 0.5rem;
 }
 
 .i1-40 .en__field:nth-of-type(1),
@@ -59,8 +59,8 @@
 .i10-40 .en__field:nth-of-type(10),
 .i11-40 .en__field:nth-of-type(11) {
   flex-basis: 40%;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+  // padding-left: 0.5rem;
+  // padding-right: 0.5rem;
 }
 
 .i1-50 .en__field:nth-of-type(1),
@@ -75,8 +75,8 @@
 .i10-50 .en__field:nth-of-type(10),
 .i11-50 .en__field:nth-of-type(11) {
   flex-basis: 50%;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+  // padding-left: 0.5rem;
+  // padding-right: 0.5rem;
 }
 
 .i1-66 .en__field:nth-of-type(1),
@@ -91,8 +91,8 @@
 .i10-66 .en__field:nth-of-type(10),
 .i11-66 .en__field:nth-of-type(11) {
   flex-basis: 66.66666%;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+  // padding-left: 0.5rem;
+  // padding-right: 0.5rem;
 }
 
 .i1-75 .en__field:nth-of-type(1),
@@ -107,8 +107,8 @@
 .i10-75 .en__field:nth-of-type(10),
 .i11-75 .en__field:nth-of-type(11) {
   flex-basis: 75%;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+  // padding-left: 0.5rem;
+  // padding-right: 0.5rem;
 }
 
 // No longer needed
@@ -129,34 +129,58 @@
 // }
 
 /* For items at the start of a row, remove left padding */
-.i1-start .en__field:nth-of-type(1),
-.i2-start .en__field:nth-of-type(2),
-.i3-start .en__field:nth-of-type(3),
-.i4-start .en__field:nth-of-type(4),
-.i5-start .en__field:nth-of-type(5),
-.i6-start .en__field:nth-of-type(6),
-.i7-start .en__field:nth-of-type(7),
-.i8-start .en__field:nth-of-type(8),
-.i9-start .en__field:nth-of-type(9),
-.i10-start .en__field:nth-of-type(10),
-.i11-start .en__field:nth-of-type(11) {
-  padding-left: 0;
-}
+// .i1-start .en__field:nth-of-type(1),
+// .i2-start .en__field:nth-of-type(2),
+// .i3-start .en__field:nth-of-type(3),
+// .i4-start .en__field:nth-of-type(4),
+// .i5-start .en__field:nth-of-type(5),
+// .i6-start .en__field:nth-of-type(6),
+// .i7-start .en__field:nth-of-type(7),
+// .i8-start .en__field:nth-of-type(8),
+// .i9-start .en__field:nth-of-type(9),
+// .i10-start .en__field:nth-of-type(10),
+// .i11-start .en__field:nth-of-type(11) {
+//   // padding-left: 0;
+//   // margin-right: 0;
+//   position: relative;
+//   left: -0.5rem;
+
+//   > *{
+//     position: relative;
+//     left: -0.5rem;
+//   }
+
+//   .en__field__element > *{
+//     margin-right: 0;
+//   }
+// }
 
 /* For items at the end of a row, remove right padding */
-.i1-end .en__field:nth-of-type(1),
-.i2-end .en__field:nth-of-type(2),
-.i3-end .en__field:nth-of-type(3),
-.i4-end .en__field:nth-of-type(4),
-.i5-end .en__field:nth-of-type(5),
-.i6-end .en__field:nth-of-type(6),
-.i7-end .en__field:nth-of-type(7),
-.i8-end .en__field:nth-of-type(8),
-.i9-end .en__field:nth-of-type(9),
-.i10-end .en__field:nth-of-type(10),
-.i11-end .en__field:nth-of-type(11) {
-  padding-right: 0;
-}
+// .i1-end .en__field:nth-of-type(1),
+// .i2-end .en__field:nth-of-type(2),
+// .i3-end .en__field:nth-of-type(3),
+// .i4-end .en__field:nth-of-type(4),
+// .i5-end .en__field:nth-of-type(5),
+// .i6-end .en__field:nth-of-type(6),
+// .i7-end .en__field:nth-of-type(7),
+// .i8-end .en__field:nth-of-type(8),
+// .i9-end .en__field:nth-of-type(9),
+// .i10-end .en__field:nth-of-type(10),
+// .i11-end .en__field:nth-of-type(11) {
+//   // padding-right: 0;
+//   // margin-left: 0;
+//   position: relative;
+//   right: -0.5rem;
+
+//   > *{
+//     position: relative;
+//     right: -0.5rem;
+//   }
+
+//   .en__field__element > *{
+//     margin-left: 0;
+//   }
+// }
 
 .i1-center .en__field:nth-of-type(1),
 .i2-center .en__field:nth-of-type(2),
@@ -326,39 +350,41 @@ body:not(#en__pagebuilder){
   .i10-m50 .en__field:nth-of-type(10),
   .i11-m50 .en__field:nth-of-type(11) {
     flex-basis: 50%;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    // padding-left: 0.5rem;
+    // padding-right: 0.5rem;
   }
 
-  /* For items at the start of a row, remove left padding */
-  .i1-mstart .en__field:nth-of-type(1),
-  .i2-mstart .en__field:nth-of-type(2),
-  .i3-mstart .en__field:nth-of-type(3),
-  .i4-mstart .en__field:nth-of-type(4),
-  .i5-mstart .en__field:nth-of-type(5),
-  .i6-mstart .en__field:nth-of-type(6),
-  .i7-mstart .en__field:nth-of-type(7),
-  .i8-mstart .en__field:nth-of-type(8),
-  .i9-mstart .en__field:nth-of-type(9),
-  .i10-mstart .en__field:nth-of-type(10),
-  .i11-mstart .en__field:nth-of-type(11) {
-    padding-left: 0;
-  }
+  // /* For items at the start of a row, remove left padding */
+  // .i1-mstart .en__field:nth-of-type(1),
+  // .i2-mstart .en__field:nth-of-type(2),
+  // .i3-mstart .en__field:nth-of-type(3),
+  // .i4-mstart .en__field:nth-of-type(4),
+  // .i5-mstart .en__field:nth-of-type(5),
+  // .i6-mstart .en__field:nth-of-type(6),
+  // .i7-mstart .en__field:nth-of-type(7),
+  // .i8-mstart .en__field:nth-of-type(8),
+  // .i9-mstart .en__field:nth-of-type(9),
+  // .i10-mstart .en__field:nth-of-type(10),
+  // .i11-mstart .en__field:nth-of-type(11) {
+  //   padding-left: 0;
+  //   margin-right: 0;
+  // }
 
-  /* For items at the end of a row, remove right padding */
-  .i1-mend .en__field:nth-of-type(1),
-  .i2-mend .en__field:nth-of-type(2),
-  .i3-mend .en__field:nth-of-type(3),
-  .i4-mend .en__field:nth-of-type(4),
-  .i5-mend .en__field:nth-of-type(5),
-  .i6-mend .en__field:nth-of-type(6),
-  .i7-mend .en__field:nth-of-type(7),
-  .i8-mend .en__field:nth-of-type(8),
-  .i9-mend .en__field:nth-of-type(9),
-  .i10-mend .en__field:nth-of-type(10),
-  .i11-mend .en__field:nth-of-type(11) {
-    padding-right: 0;
-  }
+  // /* For items at the end of a row, remove right padding */
+  // .i1-mend .en__field:nth-of-type(1),
+  // .i2-mend .en__field:nth-of-type(2),
+  // .i3-mend .en__field:nth-of-type(3),
+  // .i4-mend .en__field:nth-of-type(4),
+  // .i5-mend .en__field:nth-of-type(5),
+  // .i6-mend .en__field:nth-of-type(6),
+  // .i7-mend .en__field:nth-of-type(7),
+  // .i8-mend .en__field:nth-of-type(8),
+  // .i9-mend .en__field:nth-of-type(9),
+  // .i10-mend .en__field:nth-of-type(10),
+  // .i11-mend .en__field:nth-of-type(11) {
+  //   padding-right: 0;
+  //   margin-left: 0;
+  // }
 
   .i1-m100 .en__field:nth-of-type(1),
   .i2-m100 .en__field:nth-of-type(2),
@@ -372,7 +398,21 @@ body:not(#en__pagebuilder){
   .i10-m100 .en__field:nth-of-type(10),
   .i11-m100 .en__field:nth-of-type(11) {
     flex-basis: 100%;
-    padding-left: 0rem;
-    padding-right: 0rem;
+    // left: 0;
+    // margin-left: -0.5rem;
+    // margin-right: -0.5rem;
+    // right: 0;
+
+    // > *{
+    //   left: 0;
+    //   margin-left: -0.5rem;
+    //   margin-right: -0.5rem;
+    //   right: 0;
+    // }
+
+    // .en__field__element > *{
+    //   margin-left: 0.5rem;
+    //   margin-right: 0.5rem;
+    // }
   }
 }

--- a/packages/styles/src/_engrid-donations.scss
+++ b/packages/styles/src/_engrid-donations.scss
@@ -9,7 +9,7 @@
     --recurring-frequency__button_border-width: var(--button_border-width);
     // --recurring-frequency__button_border-color: var(--button_border-color);
     --recurring-frequency__button_border-radius: var(--button_border-radius);
-    --recurring-frequency__button_padding: var(--button_padding);
+    --recurring-frequency__button_padding: var(--button_padding) !important;
     --recurring-frequency__button_count: 4;
 
     // TYPOGRAPHY GIVING FREQUENCY BUTTON:HOVER  
@@ -32,7 +32,7 @@
     --donation-amount__button_border-width: var(--button_border-width);
     // --donation-amount__button_border-color: var(--button_border-color);
     --donation-amount__button_border-radius: var(--button_border-radius);
-    --donation-amount__button_padding: var(--button_padding);
+    --donation-amount__button_padding: var(--button_padding) !important;
     --donation-amount__button_count: 4;
 
     // TYPOGRAPHY GIVING AMOUNT BUTTON:HOVER  
@@ -59,7 +59,7 @@
     --give-by-select__button_border-width: var(--button_border-width);
     // --give-by-select__button_border-color: var(--button_border-color);
     --give-by-select__button_border-radius: var(--button_border-radius);
-    --give-by-select__button_padding: var(--button_padding);
+    --give-by-select__button_padding: var(--button_padding) !important;
     --give-by-select__button_count: 4;
 
     // TYPOGRAPHY GIVE BY SELECT BUTTON:HOVER  
@@ -78,24 +78,24 @@
 
 // Style the Donation Amount, Recurring Frequency, Radio to Buttons, and Give By Select Pseduo Fields as if they were buttons
 
-.en__field--splitselect.en__field--ccexpire {
-    flex-basis: calc((100% / 3) * 2);
-    min-width: auto;  
-    position: relative;
-    left: -0.5rem;
-}
+// .en__field--splitselect.en__field--ccexpire {
+//     flex-basis: calc((100% / 3) * 2);
+//     min-width: auto;  
+//     position: relative;
+//     left: -0.5rem;
+// }
 
-.en__field--ccvv {
-    flex-basis: calc(100% / 3);
-    min-width: auto;
-    position: relative;
-    right: -0.5rem;
-}
+// .en__field--ccvv {
+//     flex-basis: calc(100% / 3);
+//     min-width: auto;
+//     position: relative;
+//     right: -0.5rem;
+// }
 
 .en__field--recurrfreq .en__field__element,
 .en__field--recurrpay .en__field__element,
 .en__field--donationAmt .en__field__element,
-.en__field--giveBySelect .en__field__element {
+.en__field--give-by-select .en__field__element {
     justify-content: center;
 }
 
@@ -115,28 +115,28 @@
 // Hide the radio select fields when we style them like buttons
 /* prettier-ignore */
 .radio-to-buttons .en__field--radio .en__field__input--radio+.en__field__label:before,
-.en__field--giveBySelect.en__field--radio .en__field__input--radio+.en__field__label:before,
+.en__field--give-by-select.en__field--radio .en__field__input--radio+.en__field__label:before,
 .radio-to-buttons_donationAmt .en__field--donationAmt.en__field--radio .en__field__input--radio+.en__field__label:before,
 .radio-to-buttons_recurrfreq .en__field--recurrfreq.en__field--radio .en__field__input--radio+.en__field__label:before{
 	display: none;
 }
 
 .radio-to-buttons > .en__field > .en__field__element > .en__field__item:not(.en__field__item--other),
-.en__field--giveBySelect > .en__field__element .en__field__item:not(.en__field__item--other),
+.en__field--give-by-select > .en__field__element .en__field__item:not(.en__field__item--other),
 .radio-to-buttons_donationAmt > .en__field > .en__field__element .en__field__item:not(.en__field__item--other),
 .radio-to-buttons_recurrfreq > .en__field > .en__field__element .en__field__item:not(.en__field__item--other){
-    padding-left: 0;
-    padding-right: 0;
+    // padding-left: 0;
+    // padding-right: 0;
     justify-content: center;
     flex-shrink: 1;
 }
 
 .radio-to-buttons > .en__field > .en__field__element > .en__field__item--other,
-.en__field--giveBySelect > .en__field__element .en__field__item--other,
+.en__field--give-by-select > .en__field__element .en__field__item--other,
 .radio-to-buttons_donationAmt > .en__field > .en__field__element .en__field__item--other,
 .radio-to-buttons_recurrfreq > .en__field > .en__field__element .en__field__item--other{
-    padding-left: .5rem;
-    padding-right: .5rem;
+    // padding-left: .5rem;
+    // padding-right: .5rem;
     justify-content: center;
     flex-shrink: 1;
 }
@@ -145,7 +145,7 @@
     border-radius: var(--button_border-radius);
 }
 
-.en__field--giveBySelect > .en__field__element .en__field__input--other{
+.en__field--give-by-select > .en__field__element .en__field__input--other{
     border-radius: var(--give-by-select__button_border-radius);
 }
 
@@ -176,11 +176,11 @@
     border-color: var(--button_border-color);
     border-radius: var(--button_border-radius);
 	border-style: solid;
-	margin-left: 0.5rem;
-	margin-right: 0.5rem;
-    padding: var(--button_padding);
+	// margin-left: 0.5rem;
+	// margin-right: 0.5rem;
+    padding: var(--button_padding) !important;
 	background-position-x: 40px;
-    width: 100%;
+    // width: 100%;
     text-align: center;
     justify-content: center;
 }
@@ -197,7 +197,7 @@
 
 // Give By Select
 /* prettier-ignore */
-.en__field--giveBySelect.en__field--radio input[type=radio]+label{
+.en__field--give-by-select.en__field--radio input[type=radio]+label{
 	font-family: var(--give-by-select__button_font-family);
     color: var(--give-by-select__button_color);
     font-size: var(--give-by-select__button_font-size);
@@ -208,16 +208,16 @@
     border-color: var(--give-by-select__button_border-color);
     border-radius: var(--give-by-select__button_border-radius);
 	border-style: solid;
-	margin-left: 0.5rem;
-	margin-right: 0.5rem;
-    padding: var(--give-by-select__button_padding);
+	// margin-left: 0.5rem;
+	// margin-right: 0.5rem;
+    padding: var(--give-by-select__button_padding) !important;
 	background-position-x: 40px;
-    width: 100%;
+    // width: 100%;
     text-align: center;
     justify-content: center;
 }
 
-.en__field--giveBySelect > .en__field__element .en__field__item{
+.en__field--give-by-select > .en__field__element .en__field__item{
     flex-basis: calc(100% / var(--give-by-select__button_count));
 }
 
@@ -240,11 +240,11 @@
     border-color: var(--donation-amount__button_border-color);
     border-radius: var(--donation-amount__button_border-radius);
 	border-style: solid;
-	margin-left: 0.5rem;
-	margin-right: 0.5rem;
-    padding: var(--donation-amount__button_padding);
+	// margin-left: 0.5rem;
+	// margin-right: 0.5rem;
+    padding: var(--donation-amount__button_padding) !important;
 	background-position-x: 40px;
-    width: 100%;
+    // width: 100%;
     text-align: center;
     justify-content: center;
 }
@@ -272,11 +272,11 @@
     border-color: var(--recurring-frequency__button_border-color);
     border-radius: var(--recurring-frequency__button_border-radius);
 	border-style: solid;
-	margin-left: 0.5rem;
-	margin-right: 0.5rem;
-    padding: var(--recurring-frequency__button_padding);
+	// margin-left: 0.5rem;
+	// margin-right: 0.5rem;
+    padding: var(--recurring-frequency__button_padding) !important;
 	background-position-x: 40px;
-    width: 100%;
+    // width: 100%;
     text-align: center;
     justify-content: center;
 }
@@ -307,7 +307,7 @@
 
 // Give By Select
 /* prettier-ignore */
-.en__field--giveBySelect.en__field--radio .en__field__item:hover input[type=radio]+label{
+.en__field--give-by-select.en__field--radio .en__field__item:hover input[type=radio]+label{
     color: var(--give-by-select__button_color_hover);
     background-color: var(--give-by-select__button_background-color_hover);
     border-color: var(--give-by-select__button_border-color_hover);
@@ -345,7 +345,7 @@
 
 // Give By Select
 /* prettier-ignore */
-.en__field--giveBySelect.en__field--radio .en__field__item input[type=radio]:checked+label{
+.en__field--give-by-select.en__field--radio .en__field__item input[type=radio]:checked+label{
     color: var(--give-by-select__button_color_checked);
     background-color: var(--give-by-select__button_background-color_checked);
     border-color: var(--give-by-select__button_border-color_checked);
@@ -382,7 +382,7 @@
 
 // Give By Select
 /* prettier-ignore */
-.en__field--giveBySelect.en__field--radio .en__field__item:hover input[type=radio]:checked+label{
+.en__field--give-by-select.en__field--radio .en__field__item:hover input[type=radio]:checked+label{
     color: var(--give-by-select__button_color_checked);
     background-color: var(--give-by-select__button_background-color_checked);
     border-color: var(--give-by-select__button_border-color_checked);
@@ -418,7 +418,7 @@
 
 // Give By Select
 /* prettier-ignore */
-.en__field--giveBySelect.en__field--radio input[type=radio]:focus+label{
+.en__field--give-by-select.en__field--radio input[type=radio]:focus+label{
 	// outline: none;
 }
 

--- a/packages/styles/src/_engrid-errors.scss
+++ b/packages/styles/src/_engrid-errors.scss
@@ -34,20 +34,20 @@
 /* Field Level Inline Errors */
 
 /* Pick up the normal spacing on the error element to contunue form pacing continues as expected when in an error state */
-.en__component .en__field.en__field--select.en__field--validationFailed,
-.en__component .en__field.en__field--radio.en__field--validationFailed,
-.en__component .en__field.en__field--checkbox.en__field--validationFailed,
-.en__component .en__field.en__field--splittext.en__field--validationFailed,
-.en__component .en__field.en__field--tripletext.en__field--validationFailed,
-.en__component .en__field.en__field--splitselect.en__field--validationFailed,
-.en__component .en__field.en__field--tripleselect.en__field--validationFailed {
-  margin-bottom: 1rem;
-}
+// .en__component .en__field.en__field--select.en__field--validationFailed,
+// .en__component .en__field.en__field--radio.en__field--validationFailed,
+// .en__component .en__field.en__field--checkbox.en__field--validationFailed,
+// .en__component .en__field.en__field--splittext.en__field--validationFailed,
+// .en__component .en__field.en__field--tripletext.en__field--validationFailed,
+// .en__component .en__field.en__field--splitselect.en__field--validationFailed,
+// .en__component .en__field.en__field--tripleselect.en__field--validationFailed {
+//   margin-bottom: 1rem;
+// }
 
 .en__component .en__field__error {
   padding: 0.25rem 0.5rem 0 0;
   color: var(--error__color);
-  font-size: 0.75rem;
+  font-size: calc(max(75%, 10px));
   order: 3;
 }
 
@@ -61,8 +61,8 @@
 .en__field--rating .en__field__error,
 .en__field--imgselect .en__field__error,
 .en__field--withOther .en__field__error{
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+  // padding-left: 0.5rem;
+  // padding-right: 0.5rem;
 }
 
 /* @TODO Not working anymore since we removed our corresponding JS */
@@ -103,12 +103,18 @@ body.error-jump-assist .en__component .en__field__error {
   .en__field__element,
 .en__component
   .en__field.en__field--tripleselect.en__field--validationFailed
+  .en__field__element,
+.en__component
+  .en__field.en__field--imgselect.en__field--validationFailed
+  .en__field__element,
+.en__component
+  .en__field.en__field--rating.en__field--validationFailed
   .en__field__element {
   border: var(--error__border-width) solid var(--error__color);
   background-color: var(--error__color_faded);
-  padding-top: 0.5rem;
-  margin-left: 0.5rem;
-  margin-right: 0.5rem;
+  // padding-top: 0.5rem;
+  margin-left: 0rem;
+  margin-right: 0rem;
   border-radius: var(--input_border-radius);
 }
 

--- a/packages/styles/src/_engrid-fancy-errors.scss
+++ b/packages/styles/src/_engrid-fancy-errors.scss
@@ -4,104 +4,55 @@
 * ##########################################################
 */
 
-[data-engrid-errors="fancy"] .en__component .en__field__error {
-  padding: 0.25rem 0.5rem;
-  color: var(--color_white);
-  font-size: 0.75rem;
-  border-bottom-left-radius: var(--input_border-radius);
-  border-bottom-right-radius: var(--input_border-radius);
-  background-color: var(--error__color);
-  order: 3;
-}
-
-// Compound Fields
-[data-engrid-errors="fancy"] .en__field--splittext .en__field__error,
-[data-engrid-errors="fancy"] .en__field--tripletext .en__field__error,
-[data-engrid-errors="fancy"] .en__field--splitselect .en__field__error,
-[data-engrid-errors="fancy"] .en__field--tripleselect .en__field__error,
-[data-engrid-errors="fancy"] .en__field--radio .en__field__error,
-[data-engrid-errors="fancy"] .en__field--checkbox .en__field__error,
-[data-engrid-errors="fancy"] .en__field--rating .en__field__error,
-[data-engrid-errors="fancy"] .en__field--imgselect .en__field__error,
-[data-engrid-errors="fancy"] .en__field--withOther .en__field__error{
-  margin-left: 0.5rem;
-  margin-right: 0.5rem;
-}
-
 [data-engrid-errors="fancy"] {
+
+  .en__field__error {
+    padding: 0.25rem 0.5rem;
+    color: var(--color_white);
+    font-size: calc(max(75%, 10px)); // Do not let the font size fall below 10px
+    border-bottom-left-radius: var(--input_border-radius);
+    border-bottom-right-radius: var(--input_border-radius);
+    background-color: var(--error__color);
+    order: 3;
+  }
+
   .en__field--text.en__field--validationFailed input,
   .en__field--email.en__field--validationFailed input,
   .en__field--telephone.en__field--validationFailed input,
   .en__field--number.en__field--validationFailed input,
   .en__field--textarea.en__field--validationFailed textarea,
-  .en__field--select.en__field--validationFailed select {
+  .en__field--select.en__field--validationFailed select,
+  .en__field--password.en__field--validationFailed input,
+  .en__field--calendar.en__field--validationFailed input{
     border-bottom-right-radius: 0px;
     border-bottom-left-radius: 0px;
+
+    &:only-of-type{
+      margin-bottom: 0 !important;
+    }
   }
-}
+    
+  .en__field--select.en__field--withOther,
+  .en__field--radio,
+  .en__field--checkbox,
+  .en__field--splittext,
+  .en__field--tripletext,
+  .en__field--splitselect,
+  .en__field--tripleselec,
+  .en__field--calendar,
+  .en__field--imgselect,
+  .en__field--rating{
 
-[data-engrid-errors="fancy"]
-  .en__component
-  .en__field.en__field--select.en__field--withOther.en__field--validationFailed
-  .en__field__element,
-[data-engrid-errors="fancy"]
-  .en__component
-  .en__field.en__field--radio.en__field--validationFailed
-  .en__field__element,
-[data-engrid-errors="fancy"]
-  .en__component
-  .en__field.en__field--checkbox.en__field--validationFailed
-  .en__field__element,
-[data-engrid-errors="fancy"]
-  .en__component
-  .en__field.en__field--splittext.en__field--validationFailed
-  .en__field__element,
-[data-engrid-errors="fancy"]
-  .en__component
-  .en__field.en__field--tripletext.en__field--validationFailed
-  .en__field__element,
-[data-engrid-errors="fancy"]
-  .en__component
-  .en__field.en__field--splitselect.en__field--validationFailed
-  .en__field__element,
-[data-engrid-errors="fancy"]
-  .en__component
-  .en__field.en__field--tripleselect.en__field--validationFailed
-  .en__field__element {
-  border-bottom-left-radius: 0rem;
-  border-bottom-right-radius: 0rem;
-}
+    &.en__field--validationFailed .en__field__element{
 
-[data-engrid-errors="fancy"]
-  .en__component
-  .en__field.en__field--select.en__field--withOther.en__field--validationFailed.has-value
-  .en__field__element,
-[data-engrid-errors="fancy"]
-  .en__component
-  .en__field.en__field--radio.en__field--validationFailed.has-value
-  .en__field__element,
-[data-engrid-errors="fancy"]
-  .en__component
-  .en__field.en__field--checkbox.en__field--validationFailed.has-value
-  .en__field__element,
-[data-engrid-errors="fancy"]
-  .en__component
-  .en__field.en__field--splittext.en__field--validationFailed.has-value
-  .en__field__element,
-[data-engrid-errors="fancy"]
-  .en__component
-  .en__field.en__field--tripletext.en__field--validationFailed.has-value
-  .en__field__element,
-[data-engrid-errors="fancy"]
-  .en__component
-  .en__field.en__field--splitselect.en__field--validationFailed.has-value
-  .en__field__element,
-[data-engrid-errors="fancy"]
-  .en__component
-  .en__field.en__field--tripleselect.en__field--validationFailed.has-value
-  .en__field__element,
-[data-engrid-errors="fancy"] .en__field--validationFailed.has-value .en__field__error {
-  border-color: var(--error__color_grayscale);
-  background-color: var(--error__color_grayscale);
-  color: var(--color_white);
+      border-bottom-left-radius: 0rem !important;
+      border-bottom-right-radius: 0rem !important;
+    }
+
+    .en__field--validationFailed.has-value{
+      border-color: var(--error__color_grayscale);
+      background-color: var(--error__color_grayscale);
+      color: var(--color_white);
+    }
+  }
 }

--- a/packages/styles/src/_engrid-fields.scss
+++ b/packages/styles/src/_engrid-fields.scss
@@ -120,7 +120,111 @@
   --textarea_box-shadow_hover: var(--input_box-shadow_hover);
 }
 
-label{
+/************************************
+ * Form Block and Survey Block Components
+ * Why 20 pre-defined options? To cover a single form component with all of the following: * 1. First Name (50%) | 2. Last Name (50%) * 3. Email (100%) * 4. Email Opt-in (100%) * 5. Phone (100%) * 6. Phone Opt-in (100%) * 7. Street (100%) * 8. Street 2 (100%) * 9. City (33%) | 10. State (33%) | 11. Zip (33%) * 12. Country (100%) * 13. Giving Frequency (100%) * 14. Giving Amount (100%) * 15. Gift Type (100%) * 16. Credit Card Number (100%) * 17. Credit Card Expiration (50%) | 18. Credit Card CVV (50%) * 19. Custom Field (100%) * 20. Custom Field (100%)
+ ***********************************/
+
+// Form Blocks and Survey Blocks need a negative horizontal margin so the contents inside it can have a horizontal padding applied.
+.en__component--formblock,
+.en__component--svblock{
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  margin-left: -0.5rem;
+  margin-right: -0.5rem;
+
+  // All first child elements of a form block should have horizontal padding applied
+  > * {
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+  }
+
+  .en__field {
+    display: flex;
+    flex-direction: column;
+    flex-basis: 100%;
+    padding-bottom: 0rem;
+    margin-bottom: 0.5rem;
+    align-self: flex-end;
+
+    .en__field__element{
+
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+
+      .en__field__label,
+      .en__field__helpText{
+        padding-top: 0rem;
+        padding-bottom: 0rem;
+      }
+
+      // The submit buttons needs horizontal padding.
+      .en__submit{
+        padding-left: 0.5rem;
+        padding-right: 0.5rem;
+
+        // Remove horizontal padding for this single field's component
+        &.en__rangeFieldLabels {
+          padding-left: 0;
+          padding-right: 0;
+          margin-bottom: 0.5rem;
+        }
+      }
+  
+      // Compound field wrappers need a negative horizontal margin
+      &.en__field__element--checkbox,
+      &.en__field__element--radio,
+      &.en__field__element--rating,
+      &.en__field__element--imgselect,
+      &.en__field__element--splittext,
+      &.en__field__element--tripletext,
+      &.en__field__element--splitselect,
+      &.en__field__element--tripleselect,
+      &.en__field__element--withOther{
+        margin-left: -0.5rem;
+        margin-right: -0.5rem;
+  
+        // Fields inside a compound field wrapper need horizontal padding
+        .en__field__item{
+          padding-left: 0.5rem;
+          padding-right: 0.5rem;
+          padding-top: 0.5rem;
+          padding-bottom: 0.5rem;
+        }
+      }  
+    }
+  
+    &:not(.en__field--validationFailed) .en__field__element{
+      > input,
+      > select,
+      > textarea{
+        margin-top: 0.5rem;
+        margin-bottom: 0.5rem;
+      }
+    }
+
+    // "With other" compound fields need a negative horizontal margin on their wrapper
+    &.en__field--withOther{
+      .en__field__element{
+        margin-left: -0.5rem;
+        margin-right: -0.5rem;
+        
+        // Fields inside a compound field wrapper need horizontal padding
+        .en__field__item{
+          padding-left: 0.5rem;
+          padding-right: 0.5rem;
+        }
+      }
+    }
+  }
+}
+
+/************************************
+ * Labels
+ ***********************************/
+ label{
   font-family: var(--label-font-family);
   color: var(--label-color);
   font-size: var(--label-font-size);
@@ -136,9 +240,19 @@ label a.label-tooltip {
   text-decoration: underline;
   color: var(--label-color);
   font-weight: 400;
+  padding-right: 0.5rem;
 }
 
-// The use of "input.en__field__input" is needed to provide enough specificity to suprass class selectors like ".en__field__input--calendar" in enPage.css
+// Helps when the field label gets additional content added to it. https://d.pr/v/9rFaiW 
+ .en__field__label{
+  position: relative;
+  padding-bottom: 0.25rem;
+}
+
+/************************************
+ * Inputs
+ * The use of "input.en__field__input" is needed to provide enough specificity to suprass class selectors like ".en__field__input--calendar" in enPage.css
+ ***********************************/
 input,
 input.en__field__input{
   font-family: var(--input_font-family);
@@ -188,10 +302,12 @@ input[type="password"]{
   }
 }
 
-// Remove the padding set on all other input fields
+// Remove the padding and box shadow on the range slider
 input[type="range"]{
   padding-left: 0;
   padding-right: 0;
+  border: 0;
+  box-shadow: none;
 }
 
 // Removes the input shadow added by iOS 5 and later
@@ -202,11 +318,12 @@ input[type=text],
 :not(#EN__RootElement) input[type=email],
 :not(#EN__RootElement) input[type=number],
 :not(#EN__RootElement) input[type=tel]{
-  // -webkit-appearance: none;
-  // -moz-appearance: none;
   appearance: none;
 }
 
+/************************************
+* Radio Select Fields
+***********************************/
 input[type=radio]{
   + label{
     cursor: pointer;
@@ -252,6 +369,9 @@ input[type=radio]{
   }
 }
 
+/************************************
+* Checkbox Fields
+***********************************/
 // ✓
 input[type=checkbox]{
   + label{
@@ -299,8 +419,12 @@ input[type=checkbox]{
   }  
 }
 
-// For checkboxes with only an input and no label
-// @TODO See if "en__contactDetails__select" styling can be merged in
+/************************************
+* Tweet to Target Fields
+* For checkboxes with only an input and no label
+* @TODO See if "en__contactDetails__select" styling can be merged in
+***********************************/
+
 .en__twitterTarget__select{
   cursor: pointer;
   visibility: hidden; // Used to hide parent while keeping its pseduo element visible
@@ -346,6 +470,37 @@ input[type=checkbox]{
   }  
 }
 
+/************************************
+* Radio Select, Checkbox, and Email to Target Contact Fields
+***********************************/
+
+/* Custom Styling for Radio & Checkbox Inputs */
+input.en__field__input--radio,
+input.en__field__input--checkbox,
+input.en__contactDetails__select {
+  border: 0;
+  clip: rect(0 0 0 0);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+  white-space: nowrap;
+}
+
+.en__field__input--radio:focus + .en__field__label,
+.en__field__input--checkbox:focus + .en__field__label,
+.en__contactDetails__select:focus + .en__contactDetails__rows {
+  outline: -webkit-focus-ring-color auto 1px;
+  outline-offset: calc(0.5rem - 3px);
+}
+
+/************************************
+ * Select Fields
+ ***********************************/
 select,
 select.en__field__input--select,
 select.en__field__input--splitselect,
@@ -390,10 +545,14 @@ select.en__field__input--tripleselect{
       // outline: none; // Shared between input:focus, textarea:focus, and select:focus
       box-shadow: var(--select_box-shadow_hover);
   }
-
 }
 
+
+/************************************
+ * Textarea Fields
+ ***********************************/
 textarea,
+.en__field__input--textarea,
 .en__contactMessage__plainText{
   font-family: var(--textarea_font-family);
   color: var(--textarea_color);
@@ -416,7 +575,7 @@ textarea,
   border-style: solid; // Shared between input, textarea, and select
   box-shadow: var(--textarea_box-shadow);
   transition: box-shadow 0.25s, border-color 0.25s ease-in-out; // Shared between input, textarea, and select
-  height: 7rem;
+  min-height: calc(1rem + 10ch);
   resize: vertical;
 
   &:focus,
@@ -430,136 +589,61 @@ textarea,
   }
 }
 
-
-// Engaging Networks Overrides and Fixes
-.en__field__item {
-  padding: initial;
+/************************************
+ * Split Text and Split Select Fields
+ ***********************************/
+.en__field__element--splittext,
+.en__field__element--splitselect{
+  .en__field__item{
+    flex-basis: calc(100% / 2);
+  }
 }
 
-.en__field__item,
-.en__field__element--calendar,
-.en__field__element--checkbox,
-.en__field__element--email,
-.en__field__element--number,
-.en__field__element--password,
-.en__field__element--radio,
-.en__field__element--range,
-.en__field__element--rating,
-.en__field__element--select,
-.en__field__element--splitselect,
-.en__field__element--splittext,
-.en__field__element--telephone,
-.en__field__element--text,
-.en__field__element--textarea,
-.en__field__element--tripleselect,
-.en__field__element--tripletext {
+/************************************
+ * Triple Text and Triple Select Fields
+ ***********************************/
+.en__field__element--tripletext,
+.en__field__element--tripleselect{
+  .en__field__item{
+    flex-basis: calc(100% / 3);
+  }
+}
+
+/************************************
+ * Image Select Field
+ ***********************************/
+.en__imageSelectField__image{
+  padding-bottom: 0.5rem;
+}
+
+.en__field__element--imgselect{
   display: flex;
   flex-wrap: wrap;
 }
 
-/* Reset height */
-.en__field__input--textarea {
-  height: auto;
-  width: 100%;
+.en__field--imgselect .en__field__item{
+  flex-basis: calc(100% / 3);
 }
 
-/************************************
-    * General overrides of EN styles
-    ***********************************/
-
-/* In the event Theme CSS causes a hidden field to become displayed, force its display to remain hidden */
-/* This was an issue originally reported by EN staff, not sure if it still persists with recent styling updates */
-.en__hidden {
-  display: none !important;
-}
-
-.en__field,
-.en__captcha {
-  padding-bottom: 0;
-  margin-bottom: 1rem;
+.en__imageSelectField__control{
   display: flex;
   flex-direction: column;
-  position: relative;
-}
-
-/* Make the spacing between wrapping elements tighter so the user knows they're related */
-
-.en__field--select .en__field__item:not(.en__field__item--other),
-.en__field--radio .en__field__item:not(.en__field__item--other),
-.en__field--checkbox .en__field__item:not(.en__field__item--other),
-.en__field--splittext .en__field__item:not(.en__field__item--other),
-.en__field--tripletext .en__field__item:not(.en__field__item--other),
-.en__field--splitselect .en__field__item:not(.en__field__item--other),
-.en__field--tripleselect .en__field__item:not(.en__field__item--other) {
-  margin-bottom: 0.5rem;
-  // margin-right: 1rem;
-  display: flex;
-  // flex-grow: 1; /* Fields should expand to fill their flexbox container */
   align-items: center;
-  // width: 100%;
+
+  .en__field__input--imageSelectField{
+    width: auto;
+  }
 }
 
-.en__component div[class*="withOther"].en__field .en__field__item {
-  margin-bottom: 0.5rem;
-  // margin-right: 1rem;
-}
-
-/* If the form field has a hidden "other" field we need to remove the end of row spacing */
-/* NEED TO REVISIT FOR CODE CLEANUP */
-
-.en__component--formblock
-  .en__field--withOther
-  div.en__field__item:nth-last-child(2) {
-  margin-right: 0px;
-}
-
-.en__component--formblock .en__field:only-child,
-.en__component--formblock .en__field div.en__field__item:only-child {
-  // margin-left: 0;
-  // margin-right: 0;
-}
-
-.en__component--formblock .row-wrap .en__field,
-.en__component--formblock .row-wrap .en__field div.en__field__item {
-  margin-left: 0.5rem;
-  margin-right: 0.5rem;
+.en__field--imgselect .en__imageSelectField{
+  display: flex;
+  flex-direction: column;
 }
 
 /************************************
-* Inputs
-***********************************/
-
-/**
-      * Form Block Component: Select Fields
-      * Overrides EN Default Styling to ensure mobile friendly widths
-      */
-.en__field__input--select {
-  min-width: initial !important;
-}
-
-/* Custom Styling for Radio & Checkbox Inputs */
-input.en__field__input--radio,
-input.en__field__input--checkbox,
-input.en__contactDetails__select {
-  border: 0;
-  clip: rect(0 0 0 0);
-  -webkit-clip-path: inset(50%);
-  clip-path: inset(50%);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  width: 1px;
-  white-space: nowrap;
-}
-
-/* Helps when the field label gets additional content added to it. https://d.pr/v/9rFaiW */
-.en__field__label{
-  position: relative;
-}
-
-.en__contactDetails__rows {
+ * Email to Target: Contact Fields
+ ***********************************/
+ .en__contactDetails__rows {
   flex-direction: column;
   align-items: flex-start;
   width: 100%;
@@ -588,7 +672,6 @@ input.en__contactDetails__select {
   left: 0;
 }
 
-// .en__field__input--checkbox + .en__field__label:before,
 .en__contactDetails__rows:before {
   color: var(--checkbox_color);
   border-radius: var(--checkbox_border-radius);
@@ -606,14 +689,6 @@ input.en__contactDetails__select {
 // @BODY Currently, the checkbox checkmark uses the checkmark character, but if the font doesn't have this character or the designer wants to use something else, it falls apart. We should switch to an "image" based solution. Ideally, it would be a data-uri and not require a separate image asset. This should be added as default and client SCSS variable where the necessary CSS are mapped to custom properties.
 // REF: Cross browser tested radio / checkbox stylings https://codepen.io/aaroniker/pen/ZEYoxEY
 
-// .en__field__input--radio:checked + .en__field__label:before {
-//   color: var(--radio_color_selected);
-//   background-color: var(--radio_radio-background-color);
-//   // -webkit-box-shadow: inset 0 0 0 4px var(--radio_background-color);
-//   box-shadow: inset 0 0 0 4px var(--radio_background-color);
-//   border-width: var(--radio_border-width);
-// }
-
 .en__contacts:not(.en__contacts--hideCheck)
   .en__contactDetails__select:checked
   + .en__contactDetails__rows:before {
@@ -628,7 +703,7 @@ input.en__contactDetails__select {
 .en__contacts:not(.en__contacts--hideCheck)
   .en__contactDetails__select:checked
   + .en__contactDetails__rows::after {
-  // Needs and SVG safe color passed in https://stackoverflow.com/questions/25477819/scss-variable-in-background-image-with-svg-image-data-uri
+  // Needs an SVG safe color passed in https://stackoverflow.com/questions/25477819/scss-variable-in-background-image-with-svg-image-data-uri
   // content: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='21' height='16' viewBox='0 0 21 16'><path fill="#color-white" fill-rule='nonzero' d='M18.76.16L6.68 12.113l-4.44-4.392a.555.555 0 0 0-.779 0L.161 9.006a.541.541 0 0 0 0 .771L6.29 15.84a.555.555 0 0 0 .78 0l13.77-13.624a.541.541 0 0 0 0-.771L19.539.16a.555.555 0 0 0-.779 0z'/></svg>");
   // fill: var(--color_primary);
   content: "✓"; // REF: https://www.toptal.com/designers/htmlarrows/symbols/check-mark/
@@ -644,189 +719,19 @@ input.en__contactDetails__select {
   cursor: pointer;
 }
 
-/* QA Needed: Would like to find a way so that radio input focus is round rather than square. May require re-writing how radio inputs are styled */
-.en__field__input--radio:focus + .en__field__label:before,
-.en__field__input--checkbox:focus + .en__field__label:before,
-.en__contactDetails__select:focus + .en__contactDetails__rows:before {
-  // outline: var(--color_gray) auto 0.3125rem;
-  // border-color: var(--input_border-color_checked);
-}
-
-.en__field__input--radio:focus + .en__field__label,
-.en__field__input--checkbox:focus + .en__field__label,
-.en__contactDetails__select:focus + .en__contactDetails__rows {
-  outline: -webkit-focus-ring-color auto 1px;
-  outline-offset: 3px;
-}
-
-/* QA Needed: EN's hidden input field */
-.en__field--hidden {
-  display: block;
-  width: 100% !important;
-}
-
-/* Uses Padding instead of Margin because padding is counted in the Flex-basis width whereas Margin is outside */
-/* One optimization idea is to break this file up into three CSS files, 1-10, 11-20, and 21-30. That was they can be included only if that template is using them. */
-/* Should confirm if the EN class field could even hold enough chars to fit defining 20 fields plus their start/stop classes */
-/* Why 20 pre-defined options? To cover a single form component with all of the following: * 1. First Name (50%) | 2. Last Name (50%) * 3. Email (100%) * 4. Email Opt-in (100%) * 5. Phone (100%) * 6. Phone Opt-in (100%) * 7. Street (100%) * 8. Street 2 (100%) * 9. City (33%) | 10. State (33%) | 11. Zip (33%) * 12. Country (100%) * 13. Giving Frequency (100%) * 14. Giving Amount (100%) * 15. Gift Type (100%) * 16. Credit Card Number (100%) * 17. Credit Card Expiration (50%) | 18. Credit Card CVV (50%) * 19. Custom Field (100%) * 20. Custom Field (100%) */
-/* Make all en fields 100% */
-.en__field {
-  flex-basis: 100%;
-  padding-bottom: 1rem;
-  margin-bottom: 0rem;
-}
-
-/* All Single Fields that do not Wrap */
-.en__field--survey,
-.en__field--number,
-.en__field--calendar,
-.en__field--select,
-.en__field--text, 
-.en__field--telephone, 
-.en__field--range, 
-.en__field--password, 
-.en__field--calendar{
-  flex-basis: 100%;
-  padding-left: 0;
-  padding-right: 0;
-}
-
-// For Coumpound Fields that Wrap
-.en__field--checkbox,
-.en__field--radio,
-.en__field--rating,
-.en__field--imgselect,
-.en__field--splittext,
-.en__field--tripletext,
-.en__field--splitselect,
-.en__field--tripleselect,
-.en__field--withOther{
-  flex-basis: calc(100% + 1rem);
-  margin-left: -0.5rem; // Negative margins are allowed so that the buttons can reflow onto new lines without unexpected issues with padding on wrap
-  margin-right: -0.5rem; // Negative margins are allowed so that the buttons can reflow onto new lines without unexpected issues with padding on wrap
-
-  > .en__field__label,
-  > .en__field__helpText{
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
-  }
-
-}
-
-.en__field__item{
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
-}
-
-// @TODO Style "Radios with Input" to be a in a column instead of a row. Will need to use CSS Grid and not Flexbox. This is so that the last Radio when selected has the input field displayed to its immediate right on desktop and below on mobile https://d.pr/v/Ed9lyE
-
-.en__field__element--splittext,
-.en__field__element--splitselect,
-.en__field__element--tripleselect {
-  align-items: flex-start;
-}
-
-/* Includes overrides of existing CSS, need for resolve this duplicate styling */
-.en__field__element--splittext .en__field__item:nth-of-type(1),
-.en__field__element--splitselect:not(.en__field--ccexpire)
-  .en__field__item:nth-of-type(1) {
-  flex-basis: 50%;
-  padding-bottom: 0.5rem;
-  margin: 0;
-}
-
-/* Includes overrides of existing CSS, need for resolve this duplicate styling */
-.en__field__element--splittext .en__field__item:nth-of-type(2),
-.en__field__element--splitselect:not(.en__field--ccexpire)
-  .en__field__item:nth-of-type(2) {
-  flex-basis: 50%;
-  padding-bottom: 0.5rem;
-  margin: 0;
-}
-
-/* Includes overrides of existing CSS, need for resolve this duplicate styling */
-.en__field__element--tripletext .en__field__item:nth-of-type(1),
-.en__field__element--tripleselect .en__field__item:nth-of-type(1) {
-  flex-basis: calc(100% / 3);
-  padding-bottom: 0.5rem;
-  margin: 0;
-}
-
-/* Includes overrides of existing CSS, need for resolve this duplicate styling */
-.en__field__element--tripletext .en__field__item:nth-of-type(2),
-.en__field__element--tripleselect .en__field__item:nth-of-type(2) {
-  flex-basis: calc(100% / 3);
-  // padding-left: 0.5rem;
-  // padding-right: 0.5rem;
-  padding-bottom: 0.5rem;
-  margin: 0;
-}
-
-/* Includes overrides of existing CSS, need for resolve this duplicate styling */
-.en__field__element--tripletext .en__field__item:nth-of-type(3),
-.en__field__element--tripleselect .en__field__item:nth-of-type(3) {
-  flex-basis: calc(100% / 3);
-  padding-bottom: 0.5rem;
-  margin: 0;
-}
-
-.en__field__element--imgselect{
-  display: flex;
-  flex-wrap: wrap;
-}
-
-.en__field--engrid-image-select .en__field__item{
-  flex-basis: calc(100% / 3);
-}
-
-.en__imageSelectField__control{
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-
-  .en__field__input--imageSelectField{
-    width: auto;
-  }
-}
-
-.en__field--engrid-image-select .en__imageSelectField{
-  display: flex;
-  flex-direction: column;
-}
-
-.en__imageSelectField__image{
-  padding-bottom: 0.5rem;
-}
-
-.en__field--withOther .en__field__element--select .en__field__item:first-child {
-  margin-right: 0 !important;
-}
-
-/* Custom Styles */
-
-// Inline Country Helper
-.inline-country .en__field--country {
-  position: absolute;
-  right: 0;
-  align-items: flex-end;
-
-  select {
-    width: 80px;
-    // z-index: 1;
-    background-color: transparent;
-    // -webkit-box-shadow: none;
-    box-shadow: none;
-    text-align-last: right;
-  }
-}
-
-// Remove Number Input Spinners https://stackoverflow.com/a/4298216
+/************************************
+ * Number Input Spinner Field
+ * Remove Number Input Spinners https://stackoverflow.com/a/4298216
+ ***********************************/
 input[type="number"]::-webkit-inner-spin-button,
 input[type="number"]::-webkit-outer-spin-button {
   -webkit-appearance: none;
 }
 
-/* Placeholder styling */
+/************************************
+ * Field Placeholder Styling
+ * @TODO Can this be simplified because we use Autoprefixer?
+ ***********************************/
 /* Chrome, Firefox, Opera, Safari 10.1+ */::-webkit-input-placeholder {
   color: var(--color_light-gray);
   opacity: 1;
@@ -856,9 +761,48 @@ input[type="number"]::-webkit-outer-spin-button {
   color: var(--color_light-gray);
 }
 
-/* Default Stylings for Common Form Fields */
-.en__component--formblock {
+/************************************
+ * Hidden Input Field
+ ***********************************/
+
+/* In the event Theme CSS causes a hidden field to become displayed, force its display to remain hidden */
+/* This was an issue originally reported by EN staff, not sure if it still persists with recent styling updates */
+.en__hidden {
+  display: none !important;
+}
+
+/* QA Needed: EN's hidden input field */
+.en__field--hidden {
+  display: block;
+  width: 100% !important;
+}
+
+/************************************
+ * Captcha
+ ***********************************/
+
+.en__captcha {
+  padding-bottom: 0;
+  margin-bottom: 1rem;
   display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
+  flex-direction: column;
+  position: relative;
+}
+
+/************************************
+ * Inline Country Styling
+ ***********************************/
+.inline-country .en__field--country {
+  position: absolute;
+  right: 0;
+  align-items: flex-end;
+
+  select {
+    width: 80px;
+    // z-index: 1;
+    background-color: transparent;
+    // -webkit-box-shadow: none;
+    box-shadow: none;
+    text-align-last: right;
+  }
 }

--- a/packages/styles/src/_engrid-fields.scss
+++ b/packages/styles/src/_engrid-fields.scss
@@ -283,7 +283,6 @@ input.en__field__input{
       border-color: var(--input_border-color_hover);
       border-bottom-color: var(--input_border-bottom-color_hover);
       // outline: none; // Shared between input:focus, textarea:focus, and select:focus
-      box-shadow: var(--input_box-shadow_hover);
   }
 }
 

--- a/packages/styles/src/_engrid-fields.scss
+++ b/packages/styles/src/_engrid-fields.scss
@@ -480,7 +480,7 @@ input[type=checkbox]{
   visibility: hidden; // Used to hide parent while keeping its pseduo element visible
   max-width: min-content;
   content: "";
-  height: calc(var(--radio_height) + (var(--radio_border-width) * 2)); // Give it a height to match the pseduo element
+  min-height: var(--radio_height); // Give it a min height to match the pseduo element
 
   &:before{
     visibility: visible;  // Used to keep psuedo element visible while hiding the parent

--- a/packages/styles/src/_engrid-fields.scss
+++ b/packages/styles/src/_engrid-fields.scss
@@ -470,6 +470,58 @@ input[type=checkbox]{
 }
 
 /************************************
+* Premium Gift Selects
+* For radio selects with only an input and no label
+* @TODO See if "en__contactDetails__select" styling can be merged in
+***********************************/
+
+.en__pg__select input{
+  cursor: pointer;
+  visibility: hidden; // Used to hide parent while keeping its pseduo element visible
+  max-width: min-content;
+  content: "";
+  height: calc(var(--radio_height) + (var(--radio_border-width) * 2)); // Give it a height to match the pseduo element
+
+  &:before{
+    visibility: visible;  // Used to keep psuedo element visible while hiding the parent
+    content: var(--radio_content);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    // margin-right: 0.5rem;
+    color: var(--radio_color);
+    background-color: var(--radio_background-color);
+    border-style: solid;
+    border-width: var(--radio_border-width);
+    border-color: var(--radio_border-color);
+    border-radius: var(--radio_border-radius);
+    height: var(--radio_height);
+    width: var(--radio_width);
+    box-shadow: var(--radio_box-shadow);
+    display: flex; // Changed from inline-flex to flex
+  }
+
+  &:focus:before,
+  &:hover:before{
+    color: var(--radio_color_hover);
+    background-color: var(--radio_background-color_hover);
+    border-color: var(--radio_border-color_hover);
+    box-shadow: var(--radio_box-shadow_hover);
+  }
+
+  &:not(:checked):before{
+    color: transparent;
+  }  
+
+  &:checked:before{
+    color: var(--radio_color_selected);
+    background-color: var(--radio_background-color_selected);
+    border-color: var(--radio_border-color_selected);
+    box-shadow: var(--radio_box-shadow_selected);
+  }  
+}
+
+/************************************
 * Radio Select, Checkbox, and Email to Target Contact Fields
 ***********************************/
 

--- a/packages/styles/src/_engrid-page-builder.scss
+++ b/packages/styles/src/_engrid-page-builder.scss
@@ -353,3 +353,83 @@
     }
   }
 }
+
+/*
+* ##########################################################
+* # Page Builder Visual Changes for Editing Restricted Library Components
+* .edit-warning - https://d.pr/i/11bENF
+* .edit-lock - https://d.pr/i/vsA4ao
+* ##########################################################
+*/
+
+/* Make the border of componetn with an edit warning, red  */
+#en__pagebuilder .edit-warning.en__component.en__component--active.en__component--activeTarget{
+  box-shadow: 0 0 0 2px #f12222;
+}
+
+/* Make the border of component with an edit lock, black  */
+#en__pagebuilder .edit-lock.en__component.en__component--active.en__component--activeTarget {
+  box-shadow: 0 0 0 2px #000000;
+}
+
+/* Remove action handle from its normal position */
+#en__pagebuilder .edit-warning a.en__component__action--handle,
+#en__pagebuilder .edit-lock a.en__component__action--handle{
+  // background-image: none;
+  // padding-left: 6px;
+}
+
+/* Style the edit warning and lock messages to match the styling of the component actions */
+#en__pagebuilder .edit-warning.en__component.en__component--active.en__component--activeTarget .en__component__actions::after,
+#en__pagebuilder .edit-lock.en__component.en__component--active.en__component--activeTarget .en__component__actions::after{
+  display: block;
+  text-decoration: none;
+  line-height: 30px;
+  font-weight: 700;
+  padding: 0 6px 0 28px;
+  min-width: 30px;
+  text-align: left;
+  z-index: 9999;
+  white-space: nowrap;
+  // cursor: move;
+  // background-image: url(https://e-activist.com/ea-demo/frontend/build/3.63.1/images/icons/move-16-white.png) !important;
+  // background-position: 6px 50%;
+  // background-repeat: no-repeat;
+}
+
+/* Style edit warning messages to match the styling of the component actions */
+#en__pagebuilder .edit-warning.en__component.en__component--active.en__component--activeTarget .en__component__actions{
+  background-color: #f12222;
+  color: #fff;
+}
+
+/* Style the edit lock messages to match the styling of the component actions */
+#en__pagebuilder .edit-lock.en__component.en__component--active.en__component--activeTarget .en__component__actions{
+  background-color: #000000;
+  color: #fff;
+}
+
+/* Add edit warning message */
+#en__pagebuilder .edit-warning.en__component.en__component--active.en__component--activeTarget .en__component__actions::after{
+  content: "Unlink Before Editing";
+}
+
+/* Add edit lock message */
+#en__pagebuilder .edit-lock.en__component.en__component--active.en__component--activeTarget .en__component__actions::after{
+  content: "Edit From Library";
+}
+
+/* Hide the edit action when editing of the form component has been locked */
+#en__pagebuilder .edit-lock.en__component.en__component--active.en__component--activeTarget>.en__component__actions>a.en__component__action.en__component__action--settings{
+  display: none;
+}
+
+/* Change the background color of the component actions, when an edit warning is added, to further visually differentiate them */
+#en__pagebuilder .edit-warning.en__component.en__component--active.en__component--activeTarget>.en__component__actions>a.en__component__action{
+  background-color: #f12222;
+}
+
+/* Change the background color of the component actions, when an edit warning is added, to further visually differentiate them */
+#en__pagebuilder .edit-lock.en__component.en__component--active.en__component--activeTarget>.en__component__actions>a.en__component__action{
+  background-color: #000000;
+}

--- a/packages/styles/src/_engrid-premiums.scss
+++ b/packages/styles/src/_engrid-premiums.scss
@@ -1,37 +1,33 @@
+
+// CSS Grid Layout: https://grid.layoutit.com/
 .en__pg__body {
     display: grid;
-    grid-template-columns: min-content 1fr;
-    grid-template-rows: min-content 1fr;
+    grid-template-columns: min-content min-content 1fr;
+    grid-template-rows: min-content;
     grid-auto-columns: min-content;
     grid-auto-rows: min-content;
     gap: 0px 0px;
     grid-auto-flow: row;
+    align-items: center;
     grid-template-areas:
-        "en__pg__select en__pg__display"
-        "en__pg__select en__pg__detail";
-}
-
-.en__pg__select {
+      "en__pg__select en__pg__display en__pg__detail";
+  }
+  
+  .en__pg__select {
+  
     align-self: center;
     grid-area: en__pg__select;
-}
-
-.en__pg__display {
-    grid-area: en__pg__display;
-}
-
-.en__pg__detail {
-    grid-area: en__pg__detail;
-}
-
+  }
   
+  .en__pg__display { grid-area: en__pg__display; }
   
-  
+  .en__pg__detail { grid-area: en__pg__detail; }
   
   
   .en__pg__images img{
     width: auto; // Force the width to be its native size rather than 100% 
     margin: 0; // Do not "auto center" the image
+    max-width: 20vw; // Prevent the image fro ever being larger than it probably should be
 }
 
 .en__pg__select{

--- a/packages/styles/src/_engrid-premiums.scss
+++ b/packages/styles/src/_engrid-premiums.scss
@@ -1,21 +1,52 @@
-.en__pg__body{
-    display: flex;
-    flex-direction: row;
+.en__pg__body {
+    display: grid;
+    grid-template-columns: min-content 1fr;
+    grid-template-rows: min-content 1fr;
+    grid-auto-columns: min-content;
+    grid-auto-rows: min-content;
+    gap: 0px 0px;
+    grid-auto-flow: row;
+    grid-template-areas:
+        "en__pg__select en__pg__display"
+        "en__pg__select en__pg__detail";
+}
+
+.en__pg__select {
+    align-self: center;
+    grid-area: en__pg__select;
+}
+
+.en__pg__display {
+    grid-area: en__pg__display;
+}
+
+.en__pg__detail {
+    grid-area: en__pg__detail;
+}
+
+  
+  
+  
+  
+  
+  .en__pg__images img{
+    width: auto; // Force the width to be its native size rather than 100% 
+    margin: 0; // Do not "auto center" the image
 }
 
 .en__pg__select{
-    flex-basis: 15px;
+    // flex-basis: 15px;
     padding: 0;
 }
 
 .en__pg__display{
-    flex-basis: 150px;
+    // flex-basis: 150px;
     padding-top: 0;
     padding-bottom: 0;
 }
 
 .en__pg__detail{
-    flex-basis: calc(100% - 150px - 15px);
+    // flex-basis: calc(100% - 150px - 15px);
     margin-top: 0;
     padding-top: 0;
     padding-bottom: 0;        

--- a/workspace.code-workspace
+++ b/workspace.code-workspace
@@ -1,0 +1,13 @@
+{
+	"folders": [
+		{
+			"name": "engrid-scripts",
+			"path": "."
+		},
+		{
+			"name": "engrid",
+			"path": "../engrid"
+		}
+	],
+	"settings": {}
+}


### PR DESCRIPTION
I finally have ENGrid fields to the point where we don’t need to worry about the i*-start or i*-end utility classes. You can just tell it how big you want the field and don’t have to consider its placement and where it falls on a visual “row”

The credit card fields turned out to be the perfect test case because usually Credit Card Number is 100% width and it’s a single field. Then on the next row are Expiration Date and CVV. Expiration Date is a compound field, meaning it’s a fieldset with multiple fields inside it. And in this instance we want the second row to be this compound field followed by a non-compound field. Then for example on mobile, you might want those two fields to be 100% width and stack. But also for the Expiration Date fields to each be displayed at 50% width within their 100% width row. This new setup allows for all those layouts and more.

https://d.pr/v/cZYt87

I've also thrown in more coverage for field types like Radio Selects on Premium Gifts

To test/see the changes in action, look at the Brand Guide page and click the "Debug Layout" button.