### PR TITLE
Added expand-region-name

### DIFF
--- a/packages/common/dist/app.js
+++ b/packages/common/dist/app.js
@@ -1,5 +1,5 @@
 import { DonationAmount, DonationFrequency, EnForm, ProcessingFees, } from "./events";
-import { AmountLabel, Loader, ProgressBar, UpsellLightbox, ENGrid, OptionsDefaults, setRecurrFreq, PageBackground, MediaAttribution, ApplePay, CapitalizeFields, CreditCardNumbers, Ecard, ClickToExpand, legacy, LiveVariables, iFrame, ShowHideRadioCheckboxes, SimpleCountrySelect, SkipToMainContentLink, SrcDefer, NeverBounce, AutoYear, Autocomplete, RememberMe, TranslateFields, ShowIfAmount, EngridLogger, OtherAmount, MinMaxAmount, Ticker, DataReplace, DataHide, } from "./";
+import { AmountLabel, Loader, ProgressBar, UpsellLightbox, ENGrid, OptionsDefaults, setRecurrFreq, PageBackground, MediaAttribution, ApplePay, CapitalizeFields, CreditCardNumbers, Ecard, ClickToExpand, legacy, LiveVariables, iFrame, ShowHideRadioCheckboxes, SimpleCountrySelect, SkipToMainContentLink, SrcDefer, NeverBounce, AutoYear, Autocomplete, RememberMe, TranslateFields, ShowIfAmount, EngridLogger, OtherAmount, MinMaxAmount, Ticker, DataReplace, DataHide, ExpandRegionName, } from "./";
 export class App extends ENGrid {
     constructor(options) {
         super();
@@ -172,6 +172,7 @@ export class App extends ENGrid {
         new OtherAmount();
         new MinMaxAmount();
         new Ticker();
+        new ExpandRegionName();
         // Page Background
         new PageBackground();
         this.setDataAttributes();

--- a/packages/common/dist/expand-region-name.d.ts
+++ b/packages/common/dist/expand-region-name.d.ts
@@ -1,0 +1,7 @@
+import { EnForm } from "./events";
+export declare class ExpandRegionName {
+    _form: EnForm;
+    constructor();
+    private shouldRun;
+    private expandRegion;
+}

--- a/packages/common/dist/expand-region-name.js
+++ b/packages/common/dist/expand-region-name.js
@@ -1,0 +1,37 @@
+// Populates hidden supporter field "Region Long Format" with expanded name (e.g FL becomes Florida)
+import { ENGrid } from "./";
+import { EnForm } from "./events";
+export class ExpandRegionName {
+    constructor() {
+        this._form = EnForm.getInstance();
+        if (this.shouldRun()) {
+            this._form.onSubmit.subscribe(() => this.expandRegion());
+        }
+    }
+    shouldRun() {
+        const region = document.querySelector('[name="supporter.NOT_TAGGED_132"]');
+        return region !== null;
+    }
+    expandRegion() {
+        const userRegion = document.querySelector('[name="supporter.region"]'); // User entered region on the page
+        const hiddenRegion = document.querySelector('[name="supporter.NOT_TAGGED_132"]'); // Hidden region long form field
+        if (!userRegion) {
+            if (ENGrid.debug)
+                console.log("No region field to populate the hidden region field with");
+            return; // Don't populate hidden region field if user region field isn't on page
+        }
+        if (userRegion.tagName === "SELECT" && "options" in userRegion && hiddenRegion) {
+            const regionValue = userRegion.options[userRegion.selectedIndex].innerText;
+            hiddenRegion.value = regionValue;
+            if (ENGrid.debug)
+                console.log("Populated 'Region Long Format' field", hiddenRegion.value);
+        }
+        else if (userRegion.tagName === "INPUT" && hiddenRegion) {
+            const regionValue = userRegion.value;
+            hiddenRegion.value = regionValue;
+            if (ENGrid.debug)
+                console.log("Populated 'Region Long Format' field", hiddenRegion.value);
+        }
+        return;
+    }
+}

--- a/packages/common/dist/expand-region-name.js
+++ b/packages/common/dist/expand-region-name.js
@@ -9,24 +9,24 @@ export class ExpandRegionName {
         }
     }
     shouldRun() {
-        const region = document.querySelector('[name="supporter.NOT_TAGGED_132"]');
-        return region !== null;
+        return ENGrid.getOption("RegionLongFormat") !== "";
     }
     expandRegion() {
         const userRegion = document.querySelector('[name="supporter.region"]'); // User entered region on the page
-        const hiddenRegion = document.querySelector('[name="supporter.NOT_TAGGED_132"]'); // Hidden region long form field
+        const expandedRegionField = ENGrid.getOption("RegionLongFormat");
+        const hiddenRegion = document.querySelector(expandedRegionField); // Hidden region long form field
         if (!userRegion) {
             if (ENGrid.debug)
                 console.log("No region field to populate the hidden region field with");
             return; // Don't populate hidden region field if user region field isn't on page
         }
-        if (userRegion.tagName === "SELECT" && "options" in userRegion && hiddenRegion) {
+        if (userRegion.tagName === "SELECT" && "options" in userRegion && hiddenRegion && "value" in hiddenRegion) {
             const regionValue = userRegion.options[userRegion.selectedIndex].innerText;
             hiddenRegion.value = regionValue;
             if (ENGrid.debug)
                 console.log("Populated 'Region Long Format' field", hiddenRegion.value);
         }
-        else if (userRegion.tagName === "INPUT" && hiddenRegion) {
+        else if (userRegion.tagName === "INPUT" && hiddenRegion && "value" in hiddenRegion) {
             const regionValue = userRegion.value;
             hiddenRegion.value = regionValue;
             if (ENGrid.debug)

--- a/packages/common/dist/index.d.ts
+++ b/packages/common/dist/index.d.ts
@@ -35,4 +35,5 @@ export * from "./min-max-amount";
 export * from "./ticker";
 export * from "./data-replace";
 export * from "./data-hide";
+export * from "./expand-region-name";
 export * from "./events";

--- a/packages/common/dist/index.js
+++ b/packages/common/dist/index.js
@@ -36,5 +36,6 @@ export * from "./min-max-amount";
 export * from "./ticker";
 export * from "./data-replace";
 export * from "./data-hide";
+export * from "./expand-region-name";
 // Events
 export * from "./events";

--- a/packages/common/dist/interfaces/options.d.ts
+++ b/packages/common/dist/interfaces/options.d.ts
@@ -24,6 +24,7 @@ export interface Options {
     AutoYear?: boolean;
     TranslateFields?: boolean;
     Debug?: boolean;
+    RegionLongFormat?: string;
     RememberMe?: boolean | {
         remoteUrl?: string;
         cookieName?: string;

--- a/packages/common/dist/interfaces/options.js
+++ b/packages/common/dist/interfaces/options.js
@@ -24,4 +24,5 @@ export const OptionsDefaults = {
     TranslateFields: true,
     Debug: false,
     RememberMe: false,
+    RegionLongFormat: "",
 };

--- a/packages/common/src/app.ts
+++ b/packages/common/src/app.ts
@@ -39,6 +39,7 @@ import {
   Ticker,
   DataReplace,
   DataHide,
+  ExpandRegionName,
 } from "./";
 
 export class App extends ENGrid {
@@ -259,6 +260,8 @@ export class App extends ENGrid {
     new MinMaxAmount();
 
     new Ticker();
+
+    new ExpandRegionName();
 
     // Page Background
     new PageBackground();

--- a/packages/common/src/expand-region-name.ts
+++ b/packages/common/src/expand-region-name.ts
@@ -1,0 +1,45 @@
+// Populates hidden supporter field "Region Long Format" with expanded name (e.g FL becomes Florida)
+
+import { ENGrid } from "./";
+import { EnForm } from "./events";
+
+export class ExpandRegionName {
+  public _form: EnForm = EnForm.getInstance();
+
+  constructor() {
+    if(this.shouldRun()) {
+        this._form.onSubmit.subscribe(() => this.expandRegion());
+    }
+  }
+  
+  private shouldRun() {
+    const region = document.querySelector('[name="supporter.NOT_TAGGED_132"]');
+    return region !== null;
+  }
+
+  private expandRegion() {
+    const userRegion: HTMLSelectElement | HTMLInputElement | null = document.querySelector('[name="supporter.region"]'); // User entered region on the page
+    const hiddenRegion: HTMLInputElement | null = document.querySelector('[name="supporter.NOT_TAGGED_132"]'); // Hidden region long form field
+
+    if(!userRegion) {
+        if(ENGrid.debug) console.log("No region field to populate the hidden region field with");
+        return; // Don't populate hidden region field if user region field isn't on page
+    }
+
+    if(userRegion.tagName === "SELECT" && "options" in userRegion && hiddenRegion) {
+        const regionValue = userRegion.options[userRegion.selectedIndex].innerText;
+        hiddenRegion.value = regionValue;
+
+        if(ENGrid.debug) console.log("Populated 'Region Long Format' field", hiddenRegion.value);
+    }
+
+    else if(userRegion.tagName === "INPUT" && hiddenRegion) {
+        const regionValue = userRegion.value;
+        hiddenRegion.value = regionValue;
+        
+        if(ENGrid.debug) console.log("Populated 'Region Long Format' field", hiddenRegion.value);
+    }
+
+    return;
+  }
+}

--- a/packages/common/src/expand-region-name.ts
+++ b/packages/common/src/expand-region-name.ts
@@ -13,27 +13,27 @@ export class ExpandRegionName {
   }
   
   private shouldRun() {
-    const region = document.querySelector('[name="supporter.NOT_TAGGED_132"]');
-    return region !== null;
+    return ENGrid.getOption("RegionLongFormat") !== "";
   }
 
   private expandRegion() {
     const userRegion: HTMLSelectElement | HTMLInputElement | null = document.querySelector('[name="supporter.region"]'); // User entered region on the page
-    const hiddenRegion: HTMLInputElement | null = document.querySelector('[name="supporter.NOT_TAGGED_132"]'); // Hidden region long form field
+    const expandedRegionField = ENGrid.getOption("RegionLongFormat");
+    const hiddenRegion  = document.querySelector(expandedRegionField as keyof HTMLElementTagNameMap); // Hidden region long form field
 
     if(!userRegion) {
         if(ENGrid.debug) console.log("No region field to populate the hidden region field with");
         return; // Don't populate hidden region field if user region field isn't on page
     }
 
-    if(userRegion.tagName === "SELECT" && "options" in userRegion && hiddenRegion) {
+    if(userRegion.tagName === "SELECT" && "options" in userRegion && hiddenRegion && "value" in hiddenRegion) {
         const regionValue = userRegion.options[userRegion.selectedIndex].innerText;
         hiddenRegion.value = regionValue;
 
         if(ENGrid.debug) console.log("Populated 'Region Long Format' field", hiddenRegion.value);
     }
 
-    else if(userRegion.tagName === "INPUT" && hiddenRegion) {
+    else if(userRegion.tagName === "INPUT" && hiddenRegion && "value" in hiddenRegion) {
         const regionValue = userRegion.value;
         hiddenRegion.value = regionValue;
         

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -43,6 +43,7 @@ export * from "./min-max-amount";
 export * from "./ticker";
 export * from "./data-replace";
 export * from "./data-hide";
+export * from "./expand-region-name";
 
 // Events
 export * from "./events";

--- a/packages/common/src/interfaces/options.ts
+++ b/packages/common/src/interfaces/options.ts
@@ -24,6 +24,7 @@ export interface Options {
   AutoYear?: boolean;
   TranslateFields?: boolean;
   Debug?: boolean;
+  RegionLongFormat?: string;
   RememberMe?:
     | boolean
     | {
@@ -74,4 +75,5 @@ export const OptionsDefaults: Options = {
   TranslateFields: true,
   Debug: false,
   RememberMe: false,
+  RegionLongFormat: "",
 };


### PR DESCRIPTION
This branch adds the expand-region-name script. The script checks for a hidden field (Region Long Format) and populates it with the expanded version of a region abbreviation (e.g. MD becomes Maryland).