### PR TITLE
add assets=blank condition to loader

### DIFF
--- a/packages/common/dist/loader.d.ts
+++ b/packages/common/dist/loader.d.ts
@@ -6,4 +6,5 @@ export declare class Loader {
     private getOption;
     private setCssFile;
     private setJsFile;
+    private addENgridCSSUnloadedCSS;
 }

--- a/packages/common/dist/loader.js
+++ b/packages/common/dist/loader.js
@@ -23,6 +23,10 @@ export class Loader {
                 this.logger.log("engridjs=false | Removing original script:", this.jsElement);
                 this.jsElement.remove();
             }
+            if (shouldSkipCss) {
+                this.logger.log("engridcss=false | adding top banner CSS");
+                this.addENgridCSSUnloadedCSS();
+            }
             if (shouldSkipJs) {
                 this.logger.log("engridjs=false | Skipping JS load.");
                 this.logger.success("LOADED");
@@ -57,47 +61,6 @@ export class Loader {
                 cssCurrentURL.searchParams.set("v", timestamp.toString());
                 engrid_css_url = cssCurrentURL.toString();
                 break;
-            case "blank":
-                //Does not loads any ENgrid scripts and adds some CSS for debugging root cause of issues
-                this.logger.log("NOT LOADING ENGRID");
-                shouldSkipCss = true;
-                shouldSkipJs = true;
-                document.body.insertAdjacentHTML("beforeend", `<style>
-            html,
-            body {
-                background-color: #ffffff;
-            }
-
-            body {
-                opacity: 1;
-                margin: 0;
-            }
-
-            body:before {
-                content: "ENGRID UNLOADED";
-                display: flex;
-                justify-content: center;
-                align-items: center;
-                width: 100%;
-                background-color: #ffff00;
-                padding: 1rem;
-                margin-bottom: 1rem;
-                font-family: sans-serif;
-                font-weight: 600;
-            }
-
-            .en__component--advrow {
-                flex-direction: column;
-                max-width: 600px;
-                margin: 0 auto;
-            }
-
-            .en__component--advrow * {
-                max-width: 100%;
-                height: auto;
-            }
-          </style>`);
-                break;
             default:
                 this.logger.log("LOADING EXTERNAL");
                 engrid_js_url =
@@ -124,7 +87,11 @@ export class Loader {
         if (shouldSkipCss && engrid_css_url && engrid_css_url !== "") {
             this.logger.log("engridcss=false | Skipping injection of stylesheet:", engrid_css_url);
         }
-        if (!shouldSkipCss) {
+        if (shouldSkipCss) {
+            this.logger.log("engridcss=false | adding top banner CSS");
+            this.addENgridCSSUnloadedCSS();
+        }
+        else {
             this.setCssFile(engrid_css_url);
         }
         if (shouldSkipJs && this.jsElement) {
@@ -182,5 +149,42 @@ export class Loader {
         const script = document.createElement("script");
         script.setAttribute("src", url);
         document.head.appendChild(script);
+    }
+    addENgridCSSUnloadedCSS() {
+        document.body.insertAdjacentHTML("beforeend", `<style>
+        html,
+        body {
+            background-color: #ffffff;
+        }
+
+        body {
+            opacity: 1;
+            margin: 0;
+        }
+
+        body:before {
+            content: "ENGRID CSS UNLOADED";
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            width: 100%;
+            background-color: #ffff00;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            font-family: sans-serif;
+            font-weight: 600;
+        }
+
+        .en__component--advrow {
+            flex-direction: column;
+            max-width: 600px;
+            margin: 0 auto;
+        }
+
+        .en__component--advrow * {
+            max-width: 100%;
+            height: auto;
+        }
+      </style>`);
     }
 }

--- a/packages/common/dist/loader.js
+++ b/packages/common/dist/loader.js
@@ -12,8 +12,8 @@ export class Loader {
         var _a, _b, _c, _d;
         const assets = this.getOption("assets");
         const isLoaded = ENGrid.getBodyData("loaded");
-        const shouldSkipCss = this.getOption("engridcss") === "false";
-        const shouldSkipJs = this.getOption("engridjs") === "false";
+        let shouldSkipCss = this.getOption("engridcss") === "false";
+        let shouldSkipJs = this.getOption("engridjs") === "false";
         if (isLoaded || !assets) {
             if (shouldSkipCss && this.cssElement) {
                 this.logger.log("engridcss=false | Removing original stylesheet:", this.cssElement);
@@ -57,6 +57,47 @@ export class Loader {
                 cssCurrentURL.searchParams.set("v", timestamp.toString());
                 engrid_css_url = cssCurrentURL.toString();
                 break;
+            case "blank":
+                //Does not loads any ENgrid scripts and adds some CSS for debugging root cause of issues
+                this.logger.log("NOT LOADING ENGRID");
+                shouldSkipCss = true;
+                shouldSkipJs = true;
+                document.body.insertAdjacentHTML("beforeend", `<style>
+            html,
+            body {
+                background-color: #ffffff;
+            }
+
+            body {
+                opacity: 1;
+                margin: 0;
+            }
+
+            body:before {
+                content: "ENGRID UNLOADED";
+                display: flex;
+                justify-content: center;
+                align-items: center;
+                width: 100%;
+                background-color: #ffff00;
+                padding: 1rem;
+                margin-bottom: 1rem;
+                font-family: sans-serif;
+                font-weight: 600;
+            }
+
+            .en__component--advrow {
+                flex-direction: column;
+                max-width: 600px;
+                margin: 0 auto;
+            }
+
+            .en__component--advrow * {
+                max-width: 100%;
+                height: auto;
+            }
+          </style>`);
+                break;
             default:
                 this.logger.log("LOADING EXTERNAL");
                 engrid_js_url =
@@ -80,7 +121,7 @@ export class Loader {
             this.logger.log("engridcss=false | Removing original stylesheet:", this.cssElement);
             this.cssElement.remove();
         }
-        if (shouldSkipCss && engrid_css_url && engrid_css_url !== '') {
+        if (shouldSkipCss && engrid_css_url && engrid_css_url !== "") {
             this.logger.log("engridcss=false | Skipping injection of stylesheet:", engrid_css_url);
         }
         if (!shouldSkipCss) {
@@ -90,7 +131,7 @@ export class Loader {
             this.logger.log("engridjs=false | Removing original script:", this.jsElement);
             this.jsElement.remove();
         }
-        if (shouldSkipJs && engrid_js_url && engrid_js_url !== '') {
+        if (shouldSkipJs && engrid_js_url && engrid_js_url !== "") {
             this.logger.log("engridjs=false | Skipping injection of script:", engrid_js_url);
         }
         if (!shouldSkipJs) {
@@ -116,7 +157,7 @@ export class Loader {
         return null;
     }
     setCssFile(url) {
-        if (url === '') {
+        if (url === "") {
             return;
         }
         if (this.cssElement) {
@@ -134,7 +175,7 @@ export class Loader {
         }
     }
     setJsFile(url) {
-        if (url === '') {
+        if (url === "") {
             return;
         }
         this.logger.log("Injecting script:", url);

--- a/packages/common/src/loader.ts
+++ b/packages/common/src/loader.ts
@@ -16,17 +16,23 @@ export class Loader {
   public reload() {
     const assets = this.getOption("assets");
     const isLoaded = ENGrid.getBodyData("loaded");
-    const shouldSkipCss = this.getOption("engridcss") === "false";
-    const shouldSkipJs = this.getOption("engridjs") === "false";
+    let shouldSkipCss = this.getOption("engridcss") === "false";
+    let shouldSkipJs = this.getOption("engridjs") === "false";
 
     if (isLoaded || !assets) {
       if (shouldSkipCss && this.cssElement) {
-        this.logger.log("engridcss=false | Removing original stylesheet:", this.cssElement);
+        this.logger.log(
+          "engridcss=false | Removing original stylesheet:",
+          this.cssElement
+        );
         this.cssElement.remove();
       }
 
       if (shouldSkipJs && this.jsElement) {
-        this.logger.log("engridjs=false | Removing original script:", this.jsElement);
+        this.logger.log(
+          "engridjs=false | Removing original script:",
+          this.jsElement
+        );
         this.jsElement.remove();
       }
 
@@ -70,6 +76,51 @@ export class Loader {
         cssCurrentURL.searchParams.set("v", timestamp.toString());
         engrid_css_url = cssCurrentURL.toString();
         break;
+      case "blank":
+        //Does not loads any ENgrid scripts and adds some CSS for debugging root cause of issues
+        this.logger.log("NOT LOADING ENGRID");
+        shouldSkipCss = true;
+        shouldSkipJs = true;
+
+        document.body.insertAdjacentHTML(
+          "beforeend",
+          `<style>
+            html,
+            body {
+                background-color: #ffffff;
+            }
+
+            body {
+                opacity: 1;
+                margin: 0;
+            }
+
+            body:before {
+                content: "ENGRID UNLOADED";
+                display: flex;
+                justify-content: center;
+                align-items: center;
+                width: 100%;
+                background-color: #ffff00;
+                padding: 1rem;
+                margin-bottom: 1rem;
+                font-family: sans-serif;
+                font-weight: 600;
+            }
+
+            .en__component--advrow {
+                flex-direction: column;
+                max-width: 600px;
+                margin: 0 auto;
+            }
+
+            .en__component--advrow * {
+                max-width: 100%;
+                height: auto;
+            }
+          </style>`
+        );
+        break;
       default:
         this.logger.log("LOADING EXTERNAL");
         engrid_js_url =
@@ -91,12 +142,18 @@ export class Loader {
     }
 
     if (shouldSkipCss && this.cssElement) {
-      this.logger.log("engridcss=false | Removing original stylesheet:", this.cssElement);
+      this.logger.log(
+        "engridcss=false | Removing original stylesheet:",
+        this.cssElement
+      );
       this.cssElement.remove();
     }
 
-    if (shouldSkipCss && engrid_css_url && engrid_css_url !== '') {
-      this.logger.log("engridcss=false | Skipping injection of stylesheet:", engrid_css_url);
+    if (shouldSkipCss && engrid_css_url && engrid_css_url !== "") {
+      this.logger.log(
+        "engridcss=false | Skipping injection of stylesheet:",
+        engrid_css_url
+      );
     }
 
     if (!shouldSkipCss) {
@@ -104,12 +161,18 @@ export class Loader {
     }
 
     if (shouldSkipJs && this.jsElement) {
-      this.logger.log("engridjs=false | Removing original script:", this.jsElement);
+      this.logger.log(
+        "engridjs=false | Removing original script:",
+        this.jsElement
+      );
       this.jsElement.remove();
     }
 
-    if (shouldSkipJs && engrid_js_url && engrid_js_url !== '') {
-      this.logger.log("engridjs=false | Skipping injection of script:", engrid_js_url);
+    if (shouldSkipJs && engrid_js_url && engrid_js_url !== "") {
+      this.logger.log(
+        "engridjs=false | Skipping injection of script:",
+        engrid_js_url
+      );
     }
 
     if (!shouldSkipJs) {
@@ -126,7 +189,7 @@ export class Loader {
   private getOption(key: keyof Window["EngridLoader"]) {
     const urlParam = ENGrid.getUrlParameter(key);
 
-    if (urlParam && [ "assets", "engridcss", "engridjs" ].includes(key)) {
+    if (urlParam && ["assets", "engridcss", "engridjs"].includes(key)) {
       return urlParam;
     } else if (window.EngridLoader && window.EngridLoader.hasOwnProperty(key)) {
       return window.EngridLoader[key];
@@ -136,7 +199,7 @@ export class Loader {
     return null;
   }
   private setCssFile(url: string) {
-    if (url === '') {
+    if (url === "") {
       return;
     }
 
@@ -154,7 +217,7 @@ export class Loader {
     }
   }
   private setJsFile(url: string) {
-    if (url === '') {
+    if (url === "") {
       return;
     }
 

--- a/packages/common/src/loader.ts
+++ b/packages/common/src/loader.ts
@@ -36,6 +36,11 @@ export class Loader {
         this.jsElement.remove();
       }
 
+      if (shouldSkipCss) {
+        this.logger.log("engridcss=false | adding top banner CSS");
+        this.addENgridCSSUnloadedCSS();
+      }
+
       if (shouldSkipJs) {
         this.logger.log("engridjs=false | Skipping JS load.");
         this.logger.success("LOADED");
@@ -76,51 +81,6 @@ export class Loader {
         cssCurrentURL.searchParams.set("v", timestamp.toString());
         engrid_css_url = cssCurrentURL.toString();
         break;
-      case "blank":
-        //Does not loads any ENgrid scripts and adds some CSS for debugging root cause of issues
-        this.logger.log("NOT LOADING ENGRID");
-        shouldSkipCss = true;
-        shouldSkipJs = true;
-
-        document.body.insertAdjacentHTML(
-          "beforeend",
-          `<style>
-            html,
-            body {
-                background-color: #ffffff;
-            }
-
-            body {
-                opacity: 1;
-                margin: 0;
-            }
-
-            body:before {
-                content: "ENGRID UNLOADED";
-                display: flex;
-                justify-content: center;
-                align-items: center;
-                width: 100%;
-                background-color: #ffff00;
-                padding: 1rem;
-                margin-bottom: 1rem;
-                font-family: sans-serif;
-                font-weight: 600;
-            }
-
-            .en__component--advrow {
-                flex-direction: column;
-                max-width: 600px;
-                margin: 0 auto;
-            }
-
-            .en__component--advrow * {
-                max-width: 100%;
-                height: auto;
-            }
-          </style>`
-        );
-        break;
       default:
         this.logger.log("LOADING EXTERNAL");
         engrid_js_url =
@@ -156,7 +116,10 @@ export class Loader {
       );
     }
 
-    if (!shouldSkipCss) {
+    if (shouldSkipCss) {
+      this.logger.log("engridcss=false | adding top banner CSS");
+      this.addENgridCSSUnloadedCSS();
+    } else {
       this.setCssFile(engrid_css_url);
     }
 
@@ -225,5 +188,45 @@ export class Loader {
     const script = document.createElement("script");
     script.setAttribute("src", url);
     document.head.appendChild(script);
+  }
+  private addENgridCSSUnloadedCSS() {
+    document.body.insertAdjacentHTML(
+      "beforeend",
+      `<style>
+        html,
+        body {
+            background-color: #ffffff;
+        }
+
+        body {
+            opacity: 1;
+            margin: 0;
+        }
+
+        body:before {
+            content: "ENGRID CSS UNLOADED";
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            width: 100%;
+            background-color: #ffff00;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            font-family: sans-serif;
+            font-weight: 600;
+        }
+
+        .en__component--advrow {
+            flex-direction: column;
+            max-width: 600px;
+            margin: 0 auto;
+        }
+
+        .en__component--advrow * {
+            max-width: 100%;
+            height: auto;
+        }
+      </style>`
+    );
   }
 }


### PR DESCRIPTION
Adds assets=blank special case as per #176 

Hard to test this since you can't use assets=local to test it! I set up a duplicate template on Oceana's EN with my compiled CSS and JS here for testing: https://act.oceana.org/page/107218/petition/1?assets=blank