### PR TITLE
fix watchforerror

### DIFF
--- a/packages/common/dist/app.js
+++ b/packages/common/dist/app.js
@@ -101,6 +101,7 @@ export class App extends ENGrid {
             this._form.submit = true;
             this._form.submitPromise = false;
             this._form.dispatchSubmit();
+            ENGrid.watchForError(ENGrid.enableSubmit);
             if (!this._form.submit)
                 return false;
             if (this._form.submitPromise)
@@ -109,7 +110,6 @@ export class App extends ENGrid {
             // If all validation passes, we'll watch for Digital Wallets Errors, which
             // will not reload the page (thanks EN), so we will enable the submit button if
             // an error is programmatically thrown by the Digital Wallets
-            ENGrid.watchForError(ENGrid.enableSubmit);
             return true;
         };
         window.enOnError = () => {

--- a/packages/common/src/app.ts
+++ b/packages/common/src/app.ts
@@ -205,13 +205,13 @@ export class App extends ENGrid {
       this._form.submit = true;
       this._form.submitPromise = false;
       this._form.dispatchSubmit();
+      ENGrid.watchForError(ENGrid.enableSubmit);
       if (!this._form.submit) return false;
       if (this._form.submitPromise) return this._form.submitPromise;
       this.logger.success("enOnSubmit Success");
       // If all validation passes, we'll watch for Digital Wallets Errors, which
       // will not reload the page (thanks EN), so we will enable the submit button if
       // an error is programmatically thrown by the Digital Wallets
-      ENGrid.watchForError(ENGrid.enableSubmit);
       return true;
     };
     window.enOnError = () => {


### PR DESCRIPTION
In cases where we have TidyContact setting a custom submitPromise, we weren't watching for errors that don't refresh the page.

https://github.com/4site-interactive-studios/engrid-scripts/blob/main/packages/common/src/app.ts#L209
https://github.com/4site-interactive-studios/engrid-scripts/blob/main/packages/common/src/tidycontact.ts#L1358 