### PR TITLE
LOG debug mode. See debug log errors without the visual debug

### DIFF
--- a/packages/common/dist/app.js
+++ b/packages/common/dist/app.js
@@ -17,7 +17,8 @@ export class App extends ENGrid {
             return;
         // Turn Debug ON if you use local assets
         if (ENGrid.getBodyData("assets") === "local" &&
-            ENGrid.getUrlParameter("debug") !== "false") {
+            ENGrid.getUrlParameter("debug") !== "false" &&
+            ENGrid.getUrlParameter("debug") !== "log") {
             window.EngridOptions.Debug = true;
         }
         // Document Load

--- a/packages/common/dist/logger.js
+++ b/packages/common/dist/logger.js
@@ -46,7 +46,7 @@ export class EngridLogger {
         }
     }
     get log() {
-        if (!ENGrid.debug) {
+        if (!ENGrid.debug && ENGrid.getUrlParameter("debug") !== "log") {
             return () => { };
         }
         return console.log.bind(window.console, "%c" + this.emoji + " " + this.prefix + " %s", `color: ${this.color}; background-color: ${this.background}; font-size: 1.2em; padding: 4px; border-radius: 2px; font-family: monospace;`);

--- a/packages/common/src/app.ts
+++ b/packages/common/src/app.ts
@@ -89,7 +89,8 @@ export class App extends ENGrid {
     // Turn Debug ON if you use local assets
     if (
       ENGrid.getBodyData("assets") === "local" &&
-      ENGrid.getUrlParameter("debug") !== "false"
+      ENGrid.getUrlParameter("debug") !== "false" &&
+      ENGrid.getUrlParameter("debug") !== "log"
     ) {
       window.EngridOptions.Debug = true;
     }

--- a/packages/common/src/logger.ts
+++ b/packages/common/src/logger.ts
@@ -52,7 +52,7 @@ export class EngridLogger {
   }
 
   get log(): Function {
-    if (!ENGrid.debug) {
+    if (!ENGrid.debug && ENGrid.getUrlParameter("debug") !== "log") {
       return () => {};
     }
     return console.log.bind(


### PR DESCRIPTION
Something I've been using myself to see debug logs in console without the full visual debug (like showing all hidden elements). Though I'd open a PR so if you think it's useful you can merge it.

debug=log in url to use.