### PR TITLE
new 'scrollTo' postMessage and parent page handling. Do default scrol…

### DIFF
--- a/packages/common/dist/app.js
+++ b/packages/common/dist/app.js
@@ -281,11 +281,6 @@ export class App extends ENGrid {
         }
     }
     onError() {
-        // Smooth Scroll to the first .en__field--validationFailed element
-        const firstError = document.querySelector(".en__field--validationFailed");
-        if (firstError) {
-            firstError.scrollIntoView({ behavior: "smooth" });
-        }
         if (this.options.onError) {
             this.logger.danger("Client onError Triggered");
             this.options.onError();

--- a/packages/common/dist/iframe.js
+++ b/packages/common/dist/iframe.js
@@ -49,16 +49,17 @@ export class iFrame {
                 skipLink.remove();
             }
             this._form.onError.subscribe(() => {
-                // Smooth Scroll to the first .en__field--validationFailed element
+                // Get the first .en__field--validationFailed element
                 const firstError = document.querySelector(".en__field--validationFailed");
-                //send scrollTo event.
+                // Send scrollTo message
+                // Parent pages listens for this message and scrolls to the correct position
                 window.parent.postMessage({
                     scrollTo: firstError ? firstError.getBoundingClientRect().top : 0,
                 }, "*");
             });
         }
         else {
-            // When not in iframe, default behaviour
+            // When not in iframe, default behaviour, smooth scroll to first error
             this._form.onError.subscribe(() => {
                 // Smooth Scroll to the first .en__field--validationFailed element
                 const firstError = document.querySelector(".en__field--validationFailed");
@@ -66,13 +67,14 @@ export class iFrame {
                     firstError.scrollIntoView({ behavior: "smooth" });
                 }
             });
-            // Parent Page Logic
+            // Parent Page Logic (when an ENgrid form is embedded in an ENgrid page)
             window.addEventListener("message", (event) => {
                 const iframe = this.getIFrameByEvent(event);
                 if (iframe) {
                     if (event.data.hasOwnProperty("frameHeight")) {
                         iframe.style.height = event.data.frameHeight + "px";
                     }
+                    // Old scroll event logic "scroll", scrolls to correct iframe?
                     else if (event.data.hasOwnProperty("scroll") &&
                         event.data.scroll > 0) {
                         const elDistanceToTop = window.pageYOffset + iframe.getBoundingClientRect().top;
@@ -84,14 +86,17 @@ export class iFrame {
                         });
                         this.logger.log("iFrame Event - Scrolling Window to " + scrollTo);
                     }
+                    // New scroll event logic "scrollTo", scrolls to the first error
                     else if (event.data.hasOwnProperty("scrollTo")) {
+                        const scrollToPosition = event.data.scrollTo +
+                            window.scrollY +
+                            iframe.getBoundingClientRect().top;
                         window.scrollTo({
-                            top: event.data.scrollTo +
-                                window.scrollY +
-                                iframe.getBoundingClientRect().top,
+                            top: scrollToPosition,
                             left: 0,
                             behavior: "smooth",
                         });
+                        this.logger.log("iFrame Event - Scrolling Window to " + scrollToPosition);
                     }
                 }
             });

--- a/packages/common/dist/iframe.js
+++ b/packages/common/dist/iframe.js
@@ -48,8 +48,24 @@ export class iFrame {
             if (skipLink) {
                 skipLink.remove();
             }
+            this._form.onError.subscribe(() => {
+                // Smooth Scroll to the first .en__field--validationFailed element
+                const firstError = document.querySelector(".en__field--validationFailed");
+                //send scrollTo event.
+                window.parent.postMessage({
+                    scrollTo: firstError ? firstError.getBoundingClientRect().top : 0,
+                }, "*");
+            });
         }
         else {
+            // When not in iframe, default behaviour
+            this._form.onError.subscribe(() => {
+                // Smooth Scroll to the first .en__field--validationFailed element
+                const firstError = document.querySelector(".en__field--validationFailed");
+                if (firstError) {
+                    firstError.scrollIntoView({ behavior: "smooth" });
+                }
+            });
             // Parent Page Logic
             window.addEventListener("message", (event) => {
                 const iframe = this.getIFrameByEvent(event);
@@ -67,6 +83,15 @@ export class iFrame {
                             behavior: "smooth",
                         });
                         this.logger.log("iFrame Event - Scrolling Window to " + scrollTo);
+                    }
+                    else if (event.data.hasOwnProperty("scrollTo")) {
+                        window.scrollTo({
+                            top: event.data.scrollTo +
+                                window.scrollY +
+                                iframe.getBoundingClientRect().top,
+                            left: 0,
+                            behavior: "smooth",
+                        });
                     }
                 }
             });

--- a/packages/common/dist/iframe.js
+++ b/packages/common/dist/iframe.js
@@ -53,9 +53,11 @@ export class iFrame {
                 const firstError = document.querySelector(".en__field--validationFailed");
                 // Send scrollTo message
                 // Parent pages listens for this message and scrolls to the correct position
-                window.parent.postMessage({
-                    scrollTo: firstError ? firstError.getBoundingClientRect().top : 0,
-                }, "*");
+                const scrollTo = firstError
+                    ? firstError.getBoundingClientRect().top
+                    : 0;
+                this.logger.log(`iFrame Event 'scrollTo' - Position of top of first error ${scrollTo} px`); // check the message is being sent correctly
+                window.parent.postMessage({ scrollTo }, "*");
             });
         }
         else {

--- a/packages/common/src/app.ts
+++ b/packages/common/src/app.ts
@@ -427,11 +427,6 @@ export class App extends ENGrid {
   }
 
   private onError() {
-    // Smooth Scroll to the first .en__field--validationFailed element
-    const firstError = document.querySelector(".en__field--validationFailed");
-    if (firstError) {
-      firstError.scrollIntoView({ behavior: "smooth" });
-    }
     if (this.options.onError) {
       this.logger.danger("Client onError Triggered");
       this.options.onError();

--- a/packages/common/src/iframe.ts
+++ b/packages/common/src/iframe.ts
@@ -114,14 +114,18 @@ export class iFrame {
           }
           // New scroll event logic "scrollTo", scrolls to the first error
           else if (event.data.hasOwnProperty("scrollTo")) {
+            const scrollToPosition =
+              event.data.scrollTo +
+              window.scrollY +
+              iframe.getBoundingClientRect().top;
             window.scrollTo({
-              top:
-                event.data.scrollTo +
-                window.scrollY +
-                iframe.getBoundingClientRect().top,
+              top: scrollToPosition,
               left: 0,
               behavior: "smooth",
             });
+            this.logger.log(
+              "iFrame Event - Scrolling Window to " + scrollToPosition
+            );
           }
         }
       });

--- a/packages/common/src/iframe.ts
+++ b/packages/common/src/iframe.ts
@@ -71,12 +71,13 @@ export class iFrame {
         );
         // Send scrollTo message
         // Parent pages listens for this message and scrolls to the correct position
-        window.parent.postMessage(
-          {
-            scrollTo: firstError ? firstError.getBoundingClientRect().top : 0,
-          },
-          "*"
-        );
+        const scrollTo = firstError
+          ? firstError.getBoundingClientRect().top
+          : 0;
+        this.logger.log(
+          `iFrame Event 'scrollTo' - Position of top of first error ${scrollTo} px`
+        ); // check the message is being sent correctly
+        window.parent.postMessage({ scrollTo }, "*");
       });
     } else {
       // When not in iframe, default behaviour, smooth scroll to first error

--- a/reference-materials/scripts/iframe-scroll-to-error.js
+++ b/reference-materials/scripts/iframe-scroll-to-error.js
@@ -1,0 +1,15 @@
+window.addEventListener("message", (event) => {
+  //Swap selector to match your iframe for the ENgrid page
+  const iframe = document.querySelector(".en-iframe");
+
+  if (event.data.hasOwnProperty("scrollTo")) {
+    window.scrollTo({
+      top:
+        event.data.scrollTo +
+        window.scrollY +
+        iframe.getBoundingClientRect().top,
+      left: 0,
+      behavior: "smooth",
+    });
+  }
+});


### PR DESCRIPTION
…l to error handling only when not in iframe.


- Moved default handling so it's only applied when not in iFrame
- Created new postMessage and parent page handling (when ENgrid page iframes another ENgrid page)
- Added reference material for script to be used on parent pages that aren't ENgrid pages