### PR TITLE
fire change event always when paymenttype changes

### DIFF
--- a/packages/common/dist/engrid.js
+++ b/packages/common/dist/engrid.js
@@ -502,12 +502,12 @@ export class ENGrid {
             const paymentTypeOption = Array.from(enFieldPaymentType.options).find((option) => option.value.toLowerCase() === paymentType.toLowerCase());
             if (paymentTypeOption) {
                 paymentTypeOption.selected = true;
-                const event = new Event("change");
-                enFieldPaymentType.dispatchEvent(event);
             }
             else {
                 enFieldPaymentType.value = paymentType;
             }
+            const event = new Event("change");
+            enFieldPaymentType.dispatchEvent(event);
         }
     }
 }

--- a/packages/common/src/engrid.ts
+++ b/packages/common/src/engrid.ts
@@ -591,11 +591,11 @@ export abstract class ENGrid {
       );
       if (paymentTypeOption) {
         paymentTypeOption.selected = true;
-        const event = new Event("change");
-        enFieldPaymentType.dispatchEvent(event);
       } else {
         enFieldPaymentType.value = paymentType;
       }
+      const event = new Event("change");
+      enFieldPaymentType.dispatchEvent(event);
     }
   }
 }


### PR DESCRIPTION
Fixes issue with payment-type data attribute on body not changing and submit button being hidden when switching from digital wallet back to card on give-by-select.