### PR TITLE
fix tippy element targeting so it doesn't apply multiple tips to the …

### DIFF
--- a/packages/common/dist/media-attribution.js
+++ b/packages/common/dist/media-attribution.js
@@ -1,7 +1,7 @@
 /*
   Looks for specially crafted <img> links and will transform its markup to display an attribution overlay on top of the image
   Depends on "_engrid-media-attribution.scss" for styling
-  
+
   Example Image Input
   <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAABCAQAAABeK7cBAAAADUlEQVR42mO8/5+BAQAGgwHgbKwW2QAAAABJRU5ErkJggg==" data-src="https://via.placeholder.com/300x300" data-attribution-source="© Jane Doe 1">
   <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAABCAQAAABeK7cBAAAADUlEQVR42mO8/5+BAQAGgwHgbKwW2QAAAABJRU5ErkJggg==" data-src="https://via.placeholder.com/300x300" data-attribution-source="© John Doe 2" data-attribution-source-link="https://www.google.com/">
@@ -50,7 +50,7 @@ export class MediaAttribution {
                         ? mediaWithAttributionElement.dataset.attributionSourceTooltip
                         : false;
                     if (attributionSourceTooltip) {
-                        tippy(".media-with-attribution figattribution", {
+                        tippy(mediaWithAttributionElement.nextSibling, {
                             content: attributionSourceTooltip,
                             arrow: true,
                             arrowType: "default",

--- a/packages/common/src/media-attribution.ts
+++ b/packages/common/src/media-attribution.ts
@@ -1,7 +1,7 @@
 /*
   Looks for specially crafted <img> links and will transform its markup to display an attribution overlay on top of the image
   Depends on "_engrid-media-attribution.scss" for styling
-  
+
   Example Image Input
   <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAABCAQAAABeK7cBAAAADUlEQVR42mO8/5+BAQAGgwHgbKwW2QAAAABJRU5ErkJggg==" data-src="https://via.placeholder.com/300x300" data-attribution-source="© Jane Doe 1">
   <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAABCAQAAABeK7cBAAAADUlEQVR42mO8/5+BAQAGgwHgbKwW2QAAAABJRU5ErkJggg==" data-src="https://via.placeholder.com/300x300" data-attribution-source="© John Doe 2" data-attribution-source-link="https://www.google.com/">
@@ -68,7 +68,7 @@ export class MediaAttribution {
               ? mediaWithAttributionElement.dataset.attributionSourceTooltip
               : false;
           if (attributionSourceTooltip) {
-            tippy(".media-with-attribution figattribution", {
+            tippy(mediaWithAttributionElement.nextSibling, {
               content: attributionSourceTooltip,
               arrow: true,
               arrowType: "default",


### PR DESCRIPTION
…same element

The current selector for applying the tippy instance causes each iteration to apply a tippy to every figattribution on the page, so they layer on top of each other. This fixes that.

See https://support.nwf.org/page/57269/donate/1?mode=DEMO <- the banner image media attribution and background image are both layered on top of each other on the banner image tip.

Branch with fix is here: https://support.nwf.org/page/57269/donate/1?mode=DEMO&assets=attribution-fix