### PR TITLE
disable upsell for vantiv applepay

### DIFF
--- a/packages/common/dist/apple-pay.js
+++ b/packages/common/dist/apple-pay.js
@@ -108,6 +108,8 @@ export class ApplePay {
         });
     }
     onPayClicked() {
+        if (!this._form.submit)
+            return;
         const enFieldPaymentType = document.querySelector("#en__field_transaction_paymenttype");
         const applePayToken = document.getElementById("applePayToken");
         const formClass = this._form;

--- a/packages/common/dist/upsell-lightbox.js
+++ b/packages/common/dist/upsell-lightbox.js
@@ -10,6 +10,9 @@ export class UpsellLightbox {
         this.logger = new EngridLogger("UpsellLightbox", "black", "pink", "🪟");
         let options = "EngridUpsell" in window ? window.EngridUpsell : {};
         this.options = Object.assign(Object.assign({}, UpsellOptionsDefaults), options);
+        //Disable for "applepay" via Vantiv payment method. Adding it to the array like this so it persists
+        //even if the client provides custom options.
+        this.options.disablePaymentMethods.push('applepay');
         if (!this.shouldRun()) {
             this.logger.log("Upsell script should NOT run");
             // If we're not on a Donation Page, get out

--- a/packages/common/src/apple-pay.ts
+++ b/packages/common/src/apple-pay.ts
@@ -113,6 +113,7 @@ export class ApplePay {
   }
 
   private onPayClicked() {
+    if (!this._form.submit) return;
     const enFieldPaymentType = document.querySelector(
       "#en__field_transaction_paymenttype"
     ) as HTMLSelectElement;

--- a/packages/common/src/upsell-lightbox.ts
+++ b/packages/common/src/upsell-lightbox.ts
@@ -26,6 +26,9 @@ export class UpsellLightbox {
   constructor() {
     let options = "EngridUpsell" in window ? window.EngridUpsell : {};
     this.options = { ...UpsellOptionsDefaults, ...options };
+    //Disable for "applepay" via Vantiv payment method. Adding it to the array like this so it persists
+    //even if the client provides custom options.
+    this.options.disablePaymentMethods.push('applepay');
     if (!this.shouldRun()) {
       this.logger.log("Upsell script should NOT run");
       // If we're not on a Donation Page, get out


### PR DESCRIPTION
Test page: https://donate.oceanconservancy.org/page/137756/donate/1?mode=DEMO&assets=disable-upsell-applepay

Productive task: https://app.productive.io/2650-4site-interactive-studios-inc/tasks/6167519

Disable for "applepay" via Vantiv payment method. Adding it to the array like this so it persists even if the client provides custom options.
