### PR TITLE
allow use of frequency and amount utility classes on thank you pages

### DIFF
--- a/packages/common/dist/events/donation-frequency.js
+++ b/packages/common/dist/events/donation-frequency.js
@@ -23,6 +23,12 @@ export class DonationFrequency {
                 this.frequency = element.value;
             }
         });
+        //Thank you page handling for utility classes
+        if (ENGrid.getGiftProcess()) {
+            ENGrid.setBodyData("transaction-recurring-frequency", sessionStorage.getItem("engrid-transaction-recurring-frequency") ||
+                "onetime");
+            ENGrid.setBodyData("transaction-recurring", window.pageJson.recurring ? "y" : "n");
+        }
     }
     static getInstance() {
         if (!DonationFrequency.instance) {
@@ -39,6 +45,7 @@ export class DonationFrequency {
         if (this._dispatch)
             this._onFrequencyChange.dispatch(this._frequency);
         ENGrid.setBodyData("transaction-recurring-frequency", this._frequency);
+        sessionStorage.setItem("engrid-transaction-recurring-frequency", this._frequency);
     }
     get recurring() {
         return this._recurring;

--- a/packages/common/dist/show-if-amount.js
+++ b/packages/common/dist/show-if-amount.js
@@ -1,4 +1,4 @@
-import { EngridLogger } from ".";
+import { ENGrid, EngridLogger } from ".";
 import { DonationAmount } from "./events";
 export class ShowIfAmount {
     constructor() {
@@ -13,7 +13,10 @@ export class ShowIfAmount {
         this.logger.log("Show If Amount: NO ELEMENTS FOUND");
     }
     init() {
-        const amount = this._amount.amount;
+        //If we are on a thank you page, use the window.pageJson.amount
+        const amount = ENGrid.getGiftProcess()
+            ? window.pageJson.amount
+            : this._amount.amount;
         this._elements.forEach((element) => {
             this.lessthan(amount, element);
             this.lessthanorequalto(amount, element);

--- a/packages/common/src/events/donation-frequency.ts
+++ b/packages/common/src/events/donation-frequency.ts
@@ -29,6 +29,18 @@ export class DonationFrequency {
         this.frequency = element.value;
       }
     });
+    //Thank you page handling for utility classes
+    if (ENGrid.getGiftProcess()) {
+      ENGrid.setBodyData(
+        "transaction-recurring-frequency",
+        sessionStorage.getItem("engrid-transaction-recurring-frequency") ||
+          "onetime"
+      );
+      ENGrid.setBodyData(
+        "transaction-recurring",
+        window.pageJson.recurring ? "y" : "n"
+      );
+    }
   }
 
   public static getInstance(): DonationFrequency {
@@ -48,6 +60,10 @@ export class DonationFrequency {
     this._frequency = value.toLowerCase() || "onetime";
     if (this._dispatch) this._onFrequencyChange.dispatch(this._frequency);
     ENGrid.setBodyData("transaction-recurring-frequency", this._frequency);
+    sessionStorage.setItem(
+      "engrid-transaction-recurring-frequency",
+      this._frequency
+    );
   }
 
   get recurring(): string {

--- a/packages/common/src/show-if-amount.ts
+++ b/packages/common/src/show-if-amount.ts
@@ -1,4 +1,4 @@
-import { EngridLogger } from ".";
+import { ENGrid, EngridLogger } from ".";
 import { DonationAmount } from "./events";
 
 export class ShowIfAmount {
@@ -21,7 +21,10 @@ export class ShowIfAmount {
     this.logger.log("Show If Amount: NO ELEMENTS FOUND");
   }
   private init() {
-    const amount = this._amount.amount;
+    //If we are on a thank you page, use the window.pageJson.amount
+    const amount = ENGrid.getGiftProcess()
+      ? window.pageJson.amount
+      : this._amount.amount;
     this._elements.forEach((element) => {
       this.lessthan(amount, element);
       this.lessthanorequalto(amount, element);


### PR DESCRIPTION
Task: https://app.productive.io/2650-4site-interactive-studios-inc/tasks/5677689

Test page: https://preserve.nature.org/page/137955/donate/1

I've set up a test block with various test texts with different classes on the thank you page.

Awaiting final QA from client.