### PR TITLE
Premium fix amount change

### DIFF
--- a/packages/common/dist/premium-gift.js
+++ b/packages/common/dist/premium-gift.js
@@ -42,6 +42,25 @@ export class PremiumGift {
                 }
             });
         });
+        // Check when visibility of the Premium Gift Block changes.
+        // EN will add "display: none" to this element when the supporter does not qualify for a premium
+        const premiumGiftsBlock = document.querySelector(".en__component--premiumgiftblock");
+        if (premiumGiftsBlock) {
+            const observer = new MutationObserver((mutationsList) => {
+                for (const mutation of mutationsList) {
+                    if (mutation.type === "attributes" &&
+                        mutation.attributeName === "style") {
+                        if (premiumGiftsBlock.style.display === "none") {
+                            this.logger.log("Premium Gift Section hidden - removing premium gift body data attributes and premium title.");
+                            ENGrid.setBodyData("premium-gift-maximize", false);
+                            ENGrid.setBodyData("premium-gift-name", false);
+                            this.setPremiumTitle("");
+                        }
+                    }
+                }
+            });
+            observer.observe(premiumGiftsBlock, { attributes: true });
+        }
     }
     checkPremiumGift() {
         const premiumGift = document.querySelector('[name="en__pg"]:checked');

--- a/packages/common/src/premium-gift.ts
+++ b/packages/common/src/premium-gift.ts
@@ -4,7 +4,7 @@
 // 3 - Check the premium gift when click on the title or description
 // 4 - Create new {$PREMIUMTITLE} merge tag that's replaced with the premium gift name
 
-import { DonationAmount, ENGrid, EngridLogger } from ".";
+import { ENGrid, EngridLogger } from ".";
 
 export class PremiumGift {
   private logger: EngridLogger = new EngridLogger(

--- a/packages/common/src/premium-gift.ts
+++ b/packages/common/src/premium-gift.ts
@@ -4,7 +4,7 @@
 // 3 - Check the premium gift when click on the title or description
 // 4 - Create new {$PREMIUMTITLE} merge tag that's replaced with the premium gift name
 
-import { ENGrid, EngridLogger } from ".";
+import { DonationAmount, ENGrid, EngridLogger } from ".";
 
 export class PremiumGift {
   private logger: EngridLogger = new EngridLogger(
@@ -54,7 +54,34 @@ export class PremiumGift {
         }
       });
     });
+
+    // Check when visibility of the Premium Gift Block changes.
+    // EN will add "display: none" to this element when the supporter does not qualify for a premium
+    const premiumGiftsBlock: HTMLElement | null = document.querySelector(
+      ".en__component--premiumgiftblock"
+    );
+    if (premiumGiftsBlock) {
+      const observer = new MutationObserver((mutationsList) => {
+        for (const mutation of mutationsList) {
+          if (
+            mutation.type === "attributes" &&
+            mutation.attributeName === "style"
+          ) {
+            if (premiumGiftsBlock.style.display === "none") {
+              this.logger.log(
+                "Premium Gift Section hidden - removing premium gift body data attributes and premium title."
+              );
+              ENGrid.setBodyData("premium-gift-maximize", false);
+              ENGrid.setBodyData("premium-gift-name", false);
+              this.setPremiumTitle("");
+            }
+          }
+        }
+      });
+      observer.observe(premiumGiftsBlock, { attributes: true });
+    }
   }
+
   checkPremiumGift() {
     const premiumGift = document.querySelector(
       '[name="en__pg"]:checked'


### PR DESCRIPTION
Fix the data attributes for selected premium not updating when EN hides the premium (such as the donation value being lower than the premium threshold).

To replicate issue:

- Go to https://protect.worldwildlife.org/page/52717/donate/1
- Select a premium
- Change your donation amount to an amount below the threshold e.g. $5.
- Scroll down under the submit button you'll see a message about being sent a gift still.

Test again using this branch and you'll see the problem has been fixed: https://protect.worldwildlife.org/page/52717/donate/1?assets=premiums-fix