### PR TITLE
update to support fields that don't have a placeholder

### DIFF
--- a/packages/common/dist/auto-year.js
+++ b/packages/common/dist/auto-year.js
@@ -22,9 +22,14 @@ export class AutoYear {
         if (this.yearField) {
             this.yearLength =
                 this.yearField.options[this.yearField.options.length - 1].value.length;
-            while (this.yearField.options.length > 1) {
-                this.yearField.remove(1);
-            }
+            [...this.yearField.options].forEach((option) => {
+                var _a;
+                if (option.value !== "" && !isNaN(Number(option.value))) {
+                    // @ts-ignore
+                    const index = [...this.yearField.options].findIndex((i) => i.value === option.value);
+                    (_a = this.yearField) === null || _a === void 0 ? void 0 : _a.remove(index);
+                }
+            });
         }
     }
 }

--- a/packages/common/src/auto-year.ts
+++ b/packages/common/src/auto-year.ts
@@ -25,9 +25,16 @@ export class AutoYear {
     if (this.yearField) {
       this.yearLength =
         this.yearField.options[this.yearField.options.length - 1].value.length;
-      while (this.yearField.options.length > 1) {
-        this.yearField.remove(1);
-      }
+
+      [...this.yearField.options].forEach((option) => {
+        if (option.value !== "" && !isNaN(Number(option.value))) {
+          // @ts-ignore
+          const index = [...this.yearField.options].findIndex(
+            (i) => i.value === option.value
+          );
+          this.yearField?.remove(index);
+        }
+      });
     }
   }
 }


### PR DESCRIPTION
Previously the AutoYear component assumed the first option would be a placeholder and never removed the first option in the list.

This edit supports having, or not having, a placeholder by removing all non-empty string or numeric values from the options list.

test link: https://preserve.nature.org/page/138739/donate/1?mode=DEMO&locale=en-US&assets=auto-year-fix

I've tested with various configurations of the options (without and without placeholder, with placeholder value and without value).