### PR TITLE
edge case for when other amount raido has no value & fix backup donat…

### DIFF
--- a/packages/common/dist/events/donation-amount.js
+++ b/packages/common/dist/events/donation-amount.js
@@ -55,8 +55,8 @@ export class DonationAmount {
     // Set amount var with currently selected amount
     load() {
         const currentAmountField = document.querySelector('input[name="' + this._radios + '"]:checked');
-        if (currentAmountField && currentAmountField.value) {
-            let currentAmountValue = parseFloat(currentAmountField.value);
+        if (currentAmountField) {
+            let currentAmountValue = parseFloat(currentAmountField.value || "");
             if (currentAmountValue > 0) {
                 this.amount = parseFloat(currentAmountField.value);
             }
@@ -66,8 +66,10 @@ export class DonationAmount {
                 this.amount = currentAmountValue;
             }
         }
-        else if (ENGrid.checkNested(window.EngagingNetworks, "require", "_defined", "enjs", "getDonationTotal")) {
-            const total = window.EngagingNetworks.require._defined.enjs.getDonationTotal();
+        else if (ENGrid.checkNested(window.EngagingNetworks, "require", "_defined", "enjs", "getDonationTotal") &&
+            ENGrid.checkNested(window.EngagingNetworks, "require", "_defined", "enjs", "getDonationFee")) {
+            const total = window.EngagingNetworks.require._defined.enjs.getDonationTotal() -
+                window.EngagingNetworks.require._defined.enjs.getDonationFee();
             if (total) {
                 this.amount = total;
             }

--- a/packages/common/src/events/donation-amount.ts
+++ b/packages/common/src/events/donation-amount.ts
@@ -72,8 +72,8 @@ export class DonationAmount {
     const currentAmountField = document.querySelector(
       'input[name="' + this._radios + '"]:checked'
     ) as HTMLInputElement;
-    if (currentAmountField && currentAmountField.value) {
-      let currentAmountValue = parseFloat(currentAmountField.value);
+    if (currentAmountField) {
+      let currentAmountValue = parseFloat(currentAmountField.value || "");
 
       if (currentAmountValue > 0) {
         this.amount = parseFloat(currentAmountField.value);
@@ -91,10 +91,18 @@ export class DonationAmount {
         "_defined",
         "enjs",
         "getDonationTotal"
+      ) &&
+      ENGrid.checkNested(
+        window.EngagingNetworks,
+        "require",
+        "_defined",
+        "enjs",
+        "getDonationFee"
       )
     ) {
       const total =
-        window.EngagingNetworks.require._defined.enjs.getDonationTotal();
+        window.EngagingNetworks.require._defined.enjs.getDonationTotal() -
+        window.EngagingNetworks.require._defined.enjs.getDonationFee();
       if (total) {
         this.amount = total;
       }


### PR DESCRIPTION
…ion value from EN to not include the fee

--

Fixes an issue where, when falling back to EN's own donation total, it included the fee amount when donation-amount should not include that.

Also improved handling for when "Other" radio input does not have any "value" set for it. (it's not required by EN - when using a "radio with input" field type, the final radio button automatically becomes the "other" option).

Test on TNC: https://preserve.nature.org/page/80429/donate/1?assets=amount-bugfix

Here you an see we're no longer adding the fee value when we switch amounts.

