### PR TITLE
add validation properties to VGS config

### DIFF
--- a/packages/common/dist/vgs.js
+++ b/packages/common/dist/vgs.js
@@ -67,6 +67,7 @@ export class VGS {
                 },
                 // Autocomplete is not customizable
                 autoComplete: "cc-number",
+                validations: ["required", "validCardNumber"],
             },
             "transaction.ccvv": {
                 showCardIcon: false,
@@ -74,6 +75,7 @@ export class VGS {
                 hideValue: false,
                 // Autocomplete is not customizable
                 autoComplete: "cc-csc",
+                validations: ["required", "validCardSecurityCode"],
                 css: {
                     "&::placeholder": placeholderStyles,
                 },

--- a/packages/common/src/vgs.ts
+++ b/packages/common/src/vgs.ts
@@ -82,6 +82,7 @@ export class VGS {
         },
         // Autocomplete is not customizable
         autoComplete: "cc-number",
+        validations: ["required", "validCardNumber"],
       },
       "transaction.ccvv": {
         showCardIcon: false,
@@ -89,6 +90,7 @@ export class VGS {
         hideValue: false,
         // Autocomplete is not customizable
         autoComplete: "cc-csc",
+        validations: ["required", "validCardSecurityCode"],
         css: {
           "&::placeholder": placeholderStyles,
         },


### PR DESCRIPTION
EN is not validating the CVV field correctly. It shows as valid (in the css class) on page load, and remains valid regardless of what is typed in the field.

This update adds properties to the VGS config that tells it what the fields are for so it will validate them and update the classes correctly. It's from the VGS docs here: https://www.verygoodsecurity.com/docs/vgs-collect/js/integration/#field-validation

Demo is here: https://donate.shatterproof.org/page/62725/donate/1?mode=DEMO&assets=vgs-validaiton-test on this branch the CVV field will correctly have the "vgs-collect-container__invalid" class on load and switch to the valid class when 3-4 digits are entered. Without this branch it always has the valid class.