### PR TITLE
remove validation errors and classes when VGS fields are valid after …

### DIFF
--- a/packages/common/dist/vgs.js
+++ b/packages/common/dist/vgs.js
@@ -110,7 +110,9 @@ export class VGS {
                 // Create a mutation observer that cleans the VGS Elements before anything is rendered
                 const observer = new MutationObserver((mutations) => {
                     mutations.forEach((mutation) => {
-                        if (mutation.type === "childList" && mutation.addedNodes.length > 0)
+                        var _a;
+                        if (mutation.type === "childList" &&
+                            mutation.addedNodes.length > 0) {
                             mutation.addedNodes.forEach((node) => {
                                 if (node.nodeName === "IFRAME" &&
                                     mutation.previousSibling &&
@@ -119,11 +121,25 @@ export class VGS {
                                     mutation.previousSibling.remove();
                                 }
                             });
+                        }
+                        // Check if the VGS Element is valid, and remove any validation classes and errors
+                        if (mutation.type === "attributes" &&
+                            mutation.attributeName === "class") {
+                            const target = mutation.target;
+                            if (target.classList.contains("vgs-collect-container__valid")) {
+                                const fieldWrapper = target.closest(".en__field--vgs");
+                                fieldWrapper === null || fieldWrapper === void 0 ? void 0 : fieldWrapper.classList.remove("en__field--validationFailed");
+                                (_a = fieldWrapper === null || fieldWrapper === void 0 ? void 0 : fieldWrapper.querySelector(".en__field__error")) === null || _a === void 0 ? void 0 : _a.remove();
+                            }
+                        }
                     });
                 });
                 // Observe the VGS Elements
                 vgsIElements.forEach((vgsIElement) => {
-                    observer.observe(vgsIElement, { childList: true });
+                    observer.observe(vgsIElement, {
+                        childList: true,
+                        attributeFilter: ["class"],
+                    });
                 });
                 if (ENGrid.checkNested(window.EngagingNetworks, "require", "_defined", "enjs", "vgs")) {
                     window.EngagingNetworks.require._defined.enjs.vgs.init();

--- a/packages/common/src/vgs.ts
+++ b/packages/common/src/vgs.ts
@@ -130,7 +130,10 @@ export class VGS {
         // Create a mutation observer that cleans the VGS Elements before anything is rendered
         const observer = new MutationObserver((mutations) => {
           mutations.forEach((mutation) => {
-            if (mutation.type === "childList" && mutation.addedNodes.length > 0)
+            if (
+              mutation.type === "childList" &&
+              mutation.addedNodes.length > 0
+            ) {
               mutation.addedNodes.forEach((node) => {
                 if (
                   node.nodeName === "IFRAME" &&
@@ -141,11 +144,27 @@ export class VGS {
                   (mutation.previousSibling as Element).remove();
                 }
               });
+            }
+            // Check if the VGS Element is valid, and remove any validation classes and errors
+            if (
+              mutation.type === "attributes" &&
+              mutation.attributeName === "class"
+            ) {
+              const target = mutation.target as HTMLDivElement;
+              if (target.classList.contains("vgs-collect-container__valid")) {
+                const fieldWrapper = target.closest(".en__field--vgs");
+                fieldWrapper?.classList.remove("en__field--validationFailed");
+                fieldWrapper?.querySelector(".en__field__error")?.remove();
+              }
+            }
           });
         });
         // Observe the VGS Elements
         vgsIElements.forEach((vgsIElement) => {
-          observer.observe(vgsIElement, { childList: true });
+          observer.observe(vgsIElement, {
+            childList: true,
+            attributeFilter: ["class"],
+          });
         });
         if (
           ENGrid.checkNested(


### PR DESCRIPTION
…an error

Example here: https://preserve.nature.org/page/143499/donate/1

Enter an invalid credit card value e.g. just "4" and press submit. You get an error. Finish putting in the CC value e.g. "4242 4242 4242 4242" and once your card number is valid the error message and error styling disappears. Previously the error never disappeared.