### PR TITLE
New component: US-only form

### DIFF
--- a/packages/common/dist/app.js
+++ b/packages/common/dist/app.js
@@ -1,5 +1,5 @@
 import { DonationAmount, DonationFrequency, EnForm, ProcessingFees, Country, } from "./events";
-import { AmountLabel, Loader, ProgressBar, UpsellLightbox, ENGrid, OptionsDefaults, setRecurrFreq, PageBackground, MediaAttribution, ApplePay, A11y, CapitalizeFields, Ecard, ClickToExpand, Advocacy, DataAttributes, LiveVariables, iFrame, InputPlaceholders, InputHasValueAndFocus, ShowHideRadioCheckboxes, AutoCountrySelect, SkipToMainContentLink, SrcDefer, NeverBounce, AutoYear, Autocomplete, RememberMe, TranslateFields, ShowIfAmount, EngridLogger, OtherAmount, MinMaxAmount, Ticker, DataReplace, DataHide, AddNameToMessage, ExpandRegionName, AppVersion, UrlToForm, RequiredIfVisible, TidyContact, DataLayer, LiveCurrency, Autosubmit, EventTickets, SwapAmounts, DebugPanel, DebugHiddenFields, FreshAddress, BrandingHtml, CountryDisable, PremiumGift, DigitalWallets, MobileCTA, LiveFrequency, UniversalOptIn, Plaid, GiveBySelect, UrlParamsToBodyAttrs, ExitIntentLightbox, SupporterHub, FastFormFill, SetAttr, ShowIfPresent, ENValidators, CustomCurrency, VGS, PostalCodeValidator, CountryRedirect, WelcomeBack, EcardToTarget, } from "./";
+import { AmountLabel, Loader, ProgressBar, UpsellLightbox, ENGrid, OptionsDefaults, setRecurrFreq, PageBackground, MediaAttribution, ApplePay, A11y, CapitalizeFields, Ecard, ClickToExpand, Advocacy, DataAttributes, LiveVariables, iFrame, InputPlaceholders, InputHasValueAndFocus, ShowHideRadioCheckboxes, AutoCountrySelect, SkipToMainContentLink, SrcDefer, NeverBounce, AutoYear, Autocomplete, RememberMe, TranslateFields, ShowIfAmount, EngridLogger, OtherAmount, MinMaxAmount, Ticker, DataReplace, DataHide, AddNameToMessage, ExpandRegionName, AppVersion, UrlToForm, RequiredIfVisible, TidyContact, DataLayer, LiveCurrency, Autosubmit, EventTickets, SwapAmounts, DebugPanel, DebugHiddenFields, FreshAddress, BrandingHtml, CountryDisable, PremiumGift, DigitalWallets, MobileCTA, LiveFrequency, UniversalOptIn, Plaid, GiveBySelect, UrlParamsToBodyAttrs, ExitIntentLightbox, SupporterHub, FastFormFill, SetAttr, ShowIfPresent, ENValidators, CustomCurrency, VGS, PostalCodeValidator, CountryRedirect, WelcomeBack, EcardToTarget, UsOnlyForm, } from "./";
 export class App extends ENGrid {
     constructor(options) {
         super();
@@ -257,6 +257,7 @@ export class App extends ENGrid {
         new VGS();
         new WelcomeBack();
         new EcardToTarget();
+        new UsOnlyForm();
         //Debug panel
         let showDebugPanel = this.options.Debug;
         try {

--- a/packages/common/dist/index.d.ts
+++ b/packages/common/dist/index.d.ts
@@ -75,5 +75,6 @@ export * from "./vgs";
 export * from "./country-redirect";
 export * from "./welcome-back";
 export * from "./ecard-to-target";
+export * from "./us-only-form";
 export * from "./events";
 export * from "./version";

--- a/packages/common/dist/index.js
+++ b/packages/common/dist/index.js
@@ -75,6 +75,7 @@ export * from "./vgs";
 export * from "./country-redirect";
 export * from "./welcome-back";
 export * from "./ecard-to-target";
+export * from "./us-only-form";
 // Events
 export * from "./events";
 // Version

--- a/packages/common/dist/translate-fields.js
+++ b/packages/common/dist/translate-fields.js
@@ -13,6 +13,10 @@ export class TranslateFields {
         this.countriesSelect = document.querySelectorAll('select[name="supporter.country"], select[name="transaction.shipcountry"], select[name="supporter.billingCountry"], select[name="transaction.infcountry"]');
         let options = "EngridTranslate" in window ? window.EngridTranslate : {};
         this.options = TranslateOptionsDefaults;
+        // Don't run this for US-only forms.
+        if (document.querySelector(".en__component--formblock.us-only-form .en__field--country")) {
+            return;
+        }
         if (options) {
             for (let key in options) {
                 this.options[key] = this.options[key]

--- a/packages/common/dist/us-only-form.d.ts
+++ b/packages/common/dist/us-only-form.d.ts
@@ -1,0 +1,4 @@
+export declare class UsOnlyForm {
+    constructor();
+    private shouldRun;
+}

--- a/packages/common/dist/us-only-form.js
+++ b/packages/common/dist/us-only-form.js
@@ -1,0 +1,30 @@
+/*
+ * This class disables the country field and fixes the country to "United States"
+ */
+import { ENGrid } from "./";
+export class UsOnlyForm {
+    constructor() {
+        if (!this.shouldRun())
+            return;
+        if (!document.querySelector(".en__field--country .en__field__notice")) {
+            ENGrid.addHtml('<div class="en__field__notice"><em>Note: This action is limited to U.S. addresses.</em></div>', ".us-only-form .en__field--country .en__field__element", "after");
+        }
+        const countrySelect = ENGrid.getField("supporter.country");
+        countrySelect.setAttribute("disabled", "disabled");
+        let countryValue = "United States";
+        if ([...countrySelect.options].some((o) => o.value === "US")) {
+            countryValue = "US";
+        }
+        else if ([...countrySelect.options].some((o) => o.value === "USA")) {
+            countryValue = "USA";
+        }
+        ENGrid.setFieldValue("supporter.country", countryValue);
+        ENGrid.createHiddenInput("supporter.country", countryValue);
+        countrySelect.addEventListener("change", () => {
+            countrySelect.value = countryValue;
+        });
+    }
+    shouldRun() {
+        return !!document.querySelector(".en__component--formblock.us-only-form .en__field--country");
+    }
+}

--- a/packages/common/src/app.ts
+++ b/packages/common/src/app.ts
@@ -79,6 +79,7 @@ import {
   CountryRedirect,
   WelcomeBack,
   EcardToTarget,
+  UsOnlyForm,
 } from "./";
 
 export class App extends ENGrid {
@@ -418,6 +419,8 @@ export class App extends ENGrid {
     new WelcomeBack();
 
     new EcardToTarget();
+
+    new UsOnlyForm();
 
     //Debug panel
     let showDebugPanel = this.options.Debug;

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -86,6 +86,7 @@ export * from "./vgs";
 export * from "./country-redirect";
 export * from "./welcome-back";
 export * from "./ecard-to-target";
+export * from "./us-only-form";
 
 // Events
 export * from "./events";

--- a/packages/common/src/translate-fields.ts
+++ b/packages/common/src/translate-fields.ts
@@ -19,6 +19,16 @@ export class TranslateFields {
     let options: TranslateOptions =
       "EngridTranslate" in window ? window.EngridTranslate : {};
     this.options = TranslateOptionsDefaults;
+
+    // Don't run this for US-only forms.
+    if (
+      document.querySelector(
+        ".en__component--formblock.us-only-form .en__field--country"
+      )
+    ) {
+      return;
+    }
+
     if (options) {
       for (let key in options) {
         this.options[key] = this.options[key]

--- a/packages/common/src/us-only-form.ts
+++ b/packages/common/src/us-only-form.ts
@@ -1,0 +1,43 @@
+/*
+ * This class disables the country field and fixes the country to "United States"
+ */
+import { ENGrid } from "./";
+
+export class UsOnlyForm {
+  constructor() {
+    if (!this.shouldRun()) return;
+
+    if (!document.querySelector(".en__field--country .en__field__notice")) {
+      ENGrid.addHtml(
+        '<div class="en__field__notice"><em>Note: This action is limited to U.S. addresses.</em></div>',
+        ".us-only-form .en__field--country .en__field__element",
+        "after"
+      );
+    }
+
+    const countrySelect = ENGrid.getField(
+      "supporter.country"
+    ) as HTMLSelectElement;
+
+    countrySelect.setAttribute("disabled", "disabled");
+
+    let countryValue = "United States";
+    if ([...countrySelect.options].some((o) => o.value === "US")) {
+      countryValue = "US";
+    } else if ([...countrySelect.options].some((o) => o.value === "USA")) {
+      countryValue = "USA";
+    }
+
+    ENGrid.setFieldValue("supporter.country", countryValue);
+    ENGrid.createHiddenInput("supporter.country", countryValue);
+    countrySelect.addEventListener("change", () => {
+      countrySelect.value = countryValue;
+    });
+  }
+
+  private shouldRun(): boolean {
+    return !!document.querySelector(
+      ".en__component--formblock.us-only-form .en__field--country"
+    );
+  }
+}


### PR DESCRIPTION
Restricts the Country field to "United States" when the class "us-only-form" is added to the form block. It also disables the TranslateFields component when this is active to allow users to create forms with a limited number of state options.

It matches the format of the "United States" select option value to "United States", "US" or "USA", depending on how the client has set up this field.

The client will have to set up the region field accordingly - such as changing it to a select type and adding the values they want.

Test page: https://act.oceana.org/page/147625/petition/1?assets=us-only-form