### PR TITLE
New feature: Thank you page conditional content

### DIFF
--- a/packages/common/dist/ThankYouPageConditionalContent.d.ts
+++ b/packages/common/dist/ThankYouPageConditionalContent.d.ts
@@ -1,0 +1,8 @@
+export declare class ThankYouPageConditionalContent {
+    private logger;
+    constructor();
+    getShowHideRadioCheckboxesState(): any;
+    applyShowHideRadioCheckboxesState(): void;
+    deleteShowHideRadioCheckboxesState(): void;
+    private shouldRun;
+}

--- a/packages/common/dist/ThankYouPageConditionalContent.js
+++ b/packages/common/dist/ThankYouPageConditionalContent.js
@@ -1,0 +1,37 @@
+import { ENGrid } from "./engrid";
+import { EngridLogger } from "./logger";
+export class ThankYouPageConditionalContent {
+    constructor() {
+        this.logger = new EngridLogger("ThankYouPageConditionalContent");
+        if (!this.shouldRun())
+            return;
+        this.applyShowHideRadioCheckboxesState();
+    }
+    getShowHideRadioCheckboxesState() {
+        var _a;
+        try {
+            const plainState = (_a = window.sessionStorage.getItem(`engrid_ShowHideRadioCheckboxesState`)) !== null && _a !== void 0 ? _a : "";
+            return JSON.parse(plainState);
+        }
+        catch (err) {
+            return [];
+        }
+    }
+    applyShowHideRadioCheckboxesState() {
+        const state = this.getShowHideRadioCheckboxesState();
+        if (state) {
+            state.forEach((item) => {
+                if (ENGrid.getPageID() == item.page) {
+                    this.logger.log(item);
+                }
+            });
+        }
+        //this.deleteShowHideRadioCheckboxesState();
+    }
+    deleteShowHideRadioCheckboxesState() {
+        window.sessionStorage.removeItem(`engrid_ShowHideRadioCheckboxesState`);
+    }
+    shouldRun() {
+        return ENGrid.getGiftProcess();
+    }
+}

--- a/packages/common/dist/app.js
+++ b/packages/common/dist/app.js
@@ -1,5 +1,5 @@
 import { DonationAmount, DonationFrequency, EnForm, ProcessingFees, Country, } from "./events";
-import { AmountLabel, Loader, ProgressBar, UpsellLightbox, ENGrid, OptionsDefaults, setRecurrFreq, PageBackground, MediaAttribution, ApplePay, A11y, CapitalizeFields, Ecard, ClickToExpand, Advocacy, DataAttributes, LiveVariables, iFrame, InputPlaceholders, InputHasValueAndFocus, ShowHideRadioCheckboxes, AutoCountrySelect, SkipToMainContentLink, SrcDefer, NeverBounce, AutoYear, Autocomplete, RememberMe, TranslateFields, ShowIfAmount, EngridLogger, OtherAmount, MinMaxAmount, Ticker, DataReplace, DataHide, AddNameToMessage, ExpandRegionName, AppVersion, UrlToForm, RequiredIfVisible, TidyContact, DataLayer, LiveCurrency, Autosubmit, EventTickets, SwapAmounts, DebugPanel, DebugHiddenFields, FreshAddress, BrandingHtml, CountryDisable, PremiumGift, DigitalWallets, MobileCTA, LiveFrequency, UniversalOptIn, Plaid, GiveBySelect, UrlParamsToBodyAttrs, ExitIntentLightbox, SupporterHub, FastFormFill, SetAttr, ShowIfPresent, ENValidators, CustomCurrency, VGS, PostalCodeValidator, CountryRedirect, WelcomeBack, EcardToTarget, UsOnlyForm, } from "./";
+import { AmountLabel, Loader, ProgressBar, UpsellLightbox, ENGrid, OptionsDefaults, setRecurrFreq, PageBackground, MediaAttribution, ApplePay, A11y, CapitalizeFields, Ecard, ClickToExpand, Advocacy, DataAttributes, LiveVariables, iFrame, InputPlaceholders, InputHasValueAndFocus, ShowHideRadioCheckboxes, AutoCountrySelect, SkipToMainContentLink, SrcDefer, NeverBounce, AutoYear, Autocomplete, RememberMe, TranslateFields, ShowIfAmount, EngridLogger, OtherAmount, MinMaxAmount, Ticker, DataReplace, DataHide, AddNameToMessage, ExpandRegionName, AppVersion, UrlToForm, RequiredIfVisible, TidyContact, DataLayer, LiveCurrency, Autosubmit, EventTickets, SwapAmounts, DebugPanel, DebugHiddenFields, FreshAddress, BrandingHtml, CountryDisable, PremiumGift, DigitalWallets, MobileCTA, LiveFrequency, UniversalOptIn, Plaid, GiveBySelect, UrlParamsToBodyAttrs, ExitIntentLightbox, SupporterHub, FastFormFill, SetAttr, ShowIfPresent, ENValidators, CustomCurrency, VGS, PostalCodeValidator, CountryRedirect, WelcomeBack, EcardToTarget, UsOnlyForm, ThankYouPageConditionalContent, } from "./";
 export class App extends ENGrid {
     constructor(options) {
         super();
@@ -258,6 +258,7 @@ export class App extends ENGrid {
         new WelcomeBack();
         new EcardToTarget();
         new UsOnlyForm();
+        new ThankYouPageConditionalContent();
         //Debug panel
         let showDebugPanel = this.options.Debug;
         try {

--- a/packages/common/dist/index.d.ts
+++ b/packages/common/dist/index.d.ts
@@ -76,5 +76,6 @@ export * from "./country-redirect";
 export * from "./welcome-back";
 export * from "./ecard-to-target";
 export * from "./us-only-form";
+export * from "./thank-you-page-conditional-content";
 export * from "./events";
 export * from "./version";

--- a/packages/common/dist/index.js
+++ b/packages/common/dist/index.js
@@ -76,6 +76,7 @@ export * from "./country-redirect";
 export * from "./welcome-back";
 export * from "./ecard-to-target";
 export * from "./us-only-form";
+export * from "./thank-you-page-conditional-content";
 // Events
 export * from "./events";
 // Version

--- a/packages/common/dist/show-hide-radio-checkboxes.d.ts
+++ b/packages/common/dist/show-hide-radio-checkboxes.d.ts
@@ -7,5 +7,7 @@ export declare class ShowHideRadioCheckboxes {
     hide(item: HTMLInputElement): void;
     show(item: HTMLInputElement): void;
     private toggleValue;
+    getSessionState(): any;
+    storeSessionState(): void;
     constructor(elements: string, classes: string);
 }

--- a/packages/common/dist/show-hide-radio-checkboxes.js
+++ b/packages/common/dist/show-hide-radio-checkboxes.js
@@ -6,6 +6,7 @@ export class ShowHideRadioCheckboxes {
         this.classes = classes;
         this.createDataAttributes();
         this.hideAll();
+        this.storeSessionState();
         for (let i = 0; i < this.elements.length; i++) {
             let element = this.elements[i];
             if (element.checked) {
@@ -14,6 +15,7 @@ export class ShowHideRadioCheckboxes {
             element.addEventListener("change", (e) => {
                 this.hideAll();
                 this.show(element);
+                this.storeSessionState();
             });
         }
     }
@@ -106,5 +108,54 @@ export class ShowHideRadioCheckboxes {
                 }
             });
         }
+    }
+    getSessionState() {
+        var _a;
+        try {
+            const plainState = (_a = window.sessionStorage.getItem(`engrid_ShowHideRadioCheckboxesState`)) !== null && _a !== void 0 ? _a : "";
+            return JSON.parse(plainState);
+        }
+        catch (err) {
+            return [];
+        }
+    }
+    storeSessionState() {
+        const state = this.getSessionState();
+        [...this.elements].forEach((element) => {
+            var _a, _b;
+            if (!(element instanceof HTMLInputElement))
+                return;
+            if (element.type == "radio" && element.checked) {
+                //remove other items that have the same "class" property
+                state.forEach((item, index) => {
+                    if (item.class == this.classes) {
+                        state.splice(index, 1);
+                    }
+                });
+                //add the current item, with the currently active value
+                state.push({
+                    page: ENGrid.getPageID(),
+                    class: this.classes,
+                    value: element.value,
+                });
+                this.logger.log("storing radio state", state[state.length - 1]);
+            }
+            if (element.type == "checkbox") {
+                //remove other items that have the same "class" property
+                state.forEach((item, index) => {
+                    if (item.class == this.classes) {
+                        state.splice(index, 1);
+                    }
+                });
+                //add the current item, with the first checked value or "N" if none are checked
+                state.push({
+                    page: ENGrid.getPageID(),
+                    class: this.classes,
+                    value: (_b = (_a = [...this.elements].find((el) => el.checked)) === null || _a === void 0 ? void 0 : _a.value) !== null && _b !== void 0 ? _b : "N", // First checked value or "N" if none
+                });
+                this.logger.log("storing checkbox state", state[state.length - 1]);
+            }
+        });
+        window.sessionStorage.setItem(`engrid_ShowHideRadioCheckboxesState`, JSON.stringify(state));
     }
 }

--- a/packages/common/dist/thank-you-page-conditional-content.d.ts
+++ b/packages/common/dist/thank-you-page-conditional-content.d.ts
@@ -1,0 +1,8 @@
+export declare class ThankYouPageConditionalContent {
+    private logger;
+    constructor();
+    getShowHideRadioCheckboxesState(): any;
+    applyShowHideRadioCheckboxesState(): void;
+    deleteShowHideRadioCheckboxesState(): void;
+    private shouldRun;
+}

--- a/packages/common/dist/thank-you-page-conditional-content.js
+++ b/packages/common/dist/thank-you-page-conditional-content.js
@@ -1,0 +1,46 @@
+import { ENGrid, EngridLogger } from ".";
+export class ThankYouPageConditionalContent {
+    constructor() {
+        this.logger = new EngridLogger("ThankYouPageConditionalContent");
+        if (!this.shouldRun())
+            return;
+        this.applyShowHideRadioCheckboxesState();
+    }
+    getShowHideRadioCheckboxesState() {
+        var _a;
+        try {
+            const plainState = (_a = window.sessionStorage.getItem(`engrid_ShowHideRadioCheckboxesState`)) !== null && _a !== void 0 ? _a : "";
+            return JSON.parse(plainState);
+        }
+        catch (err) {
+            return [];
+        }
+    }
+    applyShowHideRadioCheckboxesState() {
+        const state = this.getShowHideRadioCheckboxesState();
+        if (state) {
+            state.forEach((item) => {
+                this.logger.log("Processing TY page conditional content item:", item);
+                if (ENGrid.getPageID() === item.page) {
+                    document
+                        .querySelectorAll(`[class*="${item.class}"]`)
+                        .forEach((el) => {
+                        el.classList.add("hide");
+                    });
+                    document
+                        .querySelectorAll(`.${item.class}${item.value}`)
+                        .forEach((el) => {
+                        el.classList.remove("hide");
+                    });
+                }
+            });
+        }
+        this.deleteShowHideRadioCheckboxesState();
+    }
+    deleteShowHideRadioCheckboxesState() {
+        window.sessionStorage.removeItem(`engrid_ShowHideRadioCheckboxesState`);
+    }
+    shouldRun() {
+        return ENGrid.getGiftProcess();
+    }
+}

--- a/packages/common/src/app.ts
+++ b/packages/common/src/app.ts
@@ -80,6 +80,7 @@ import {
   WelcomeBack,
   EcardToTarget,
   UsOnlyForm,
+  ThankYouPageConditionalContent,
 } from "./";
 
 export class App extends ENGrid {
@@ -421,6 +422,8 @@ export class App extends ENGrid {
     new EcardToTarget();
 
     new UsOnlyForm();
+
+    new ThankYouPageConditionalContent();
 
     //Debug panel
     let showDebugPanel = this.options.Debug;

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -87,6 +87,7 @@ export * from "./country-redirect";
 export * from "./welcome-back";
 export * from "./ecard-to-target";
 export * from "./us-only-form";
+export * from "./thank-you-page-conditional-content";
 
 // Events
 export * from "./events";

--- a/packages/common/src/thank-you-page-conditional-content.ts
+++ b/packages/common/src/thank-you-page-conditional-content.ts
@@ -1,0 +1,63 @@
+import { ENGrid, EngridLogger } from ".";
+
+interface ShowHideRadioCheckboxesStateItem {
+  page: number;
+  class: string;
+  value: string;
+}
+
+export class ThankYouPageConditionalContent {
+  private logger: EngridLogger = new EngridLogger(
+    "ThankYouPageConditionalContent"
+  );
+
+  constructor() {
+    if (!this.shouldRun()) return;
+
+    this.applyShowHideRadioCheckboxesState();
+  }
+
+  getShowHideRadioCheckboxesState() {
+    try {
+      const plainState =
+        window.sessionStorage.getItem(`engrid_ShowHideRadioCheckboxesState`) ??
+        "";
+      return JSON.parse(plainState);
+    } catch (err) {
+      return [];
+    }
+  }
+
+  applyShowHideRadioCheckboxesState() {
+    const state = this.getShowHideRadioCheckboxesState();
+
+    if (state) {
+      state.forEach((item: ShowHideRadioCheckboxesStateItem) => {
+        this.logger.log("Processing TY page conditional content item:", item);
+
+        if (ENGrid.getPageID() === item.page) {
+          document
+            .querySelectorAll(`[class*="${item.class}"]`)
+            .forEach((el) => {
+              el.classList.add("hide");
+            });
+          document
+            .querySelectorAll(`.${item.class}${item.value}`)
+            .forEach((el) => {
+              el.classList.remove("hide");
+            });
+        }
+      });
+    }
+
+    this.deleteShowHideRadioCheckboxesState();
+  }
+
+  deleteShowHideRadioCheckboxesState() {
+    window.sessionStorage.removeItem(`engrid_ShowHideRadioCheckboxesState`);
+  }
+
+  private shouldRun() {
+    return ENGrid.getGiftProcess();
+  }
+}


### PR DESCRIPTION
Task: https://app.productive.io/2650-4site-interactive-studios-inc/tasks/6518937

This feature implements the request for: _add the "Hide any element based on the selected value of a checkbox or radio select field" class type to work on thank you pages_

It extends `ShowHideRadioCheckoxes` to save the state of each set of controls initialised by that class into sessionStorage. Then, a new class `ThankYouPageConditionalContent` handles applying that state on a thank you page.

Because of the fragile nature of handling input states this way, there are some defensive practises implemented in the handling such as:

- Saving the page ID with each state item in session storage, and only applying those states on the thank you page is the page ID matches.
- Using sessionStorage for automatic cleanup when a tab/window is closed.
- Only applying changes on 1 page immediately after a donation is processed - when `pageJson.giftProcess` is `true`
- Removing the session storage item after the conditional content script has ran 1 time.

This means this code will work for its intended purpose - displaying some conditional content on a thank you page - but would need further considerations if it were to be extended to generally allow conditional content to persist across chained pages.

Test page: https://protect.worldwildlife.org/page/66734/donate/1

The test page is set up to load a build of WWF's theme using this engird-scripts branch and has a block on the thank you page for various pieces of conditional content. This PR is only concerned with the final section of that block under the header of "Hide any element based on the selected value of a checkbox or radio select field".