### PR TITLE
adjust fast form for the welcome back component to activate when all …

### DIFF
--- a/packages/common/dist/fast-form-fill.js
+++ b/packages/common/dist/fast-form-fill.js
@@ -25,9 +25,9 @@ export class FastFormFill {
         }
     }
     run() {
-        const fastPersonalDetailsFormBlock = document.querySelector(".en__component--formblock.fast-personal-details");
-        if (fastPersonalDetailsFormBlock) {
-            if (FastFormFill.allMandatoryInputsAreFilled(fastPersonalDetailsFormBlock)) {
+        const fastPersonalDetailsFormBlocks = document.querySelectorAll(".en__component--formblock.fast-personal-details");
+        if (fastPersonalDetailsFormBlocks) {
+            if ([...fastPersonalDetailsFormBlocks].every((formBlock) => FastFormFill.allMandatoryInputsAreFilled(formBlock))) {
                 this.logger.log("Personal details - All mandatory inputs are filled");
                 ENGrid.setBodyData("hide-fast-personal-details", "true");
             }
@@ -36,9 +36,9 @@ export class FastFormFill {
                 ENGrid.setBodyData("hide-fast-personal-details", "false");
             }
         }
-        const fastAddressDetailsFormBlock = document.querySelector(".en__component--formblock.fast-address-details");
-        if (fastAddressDetailsFormBlock) {
-            if (FastFormFill.allMandatoryInputsAreFilled(fastAddressDetailsFormBlock)) {
+        const fastAddressDetailsFormBlocks = document.querySelectorAll(".en__component--formblock.fast-address-details");
+        if (fastAddressDetailsFormBlocks) {
+            if ([...fastAddressDetailsFormBlocks].every((formBlock) => FastFormFill.allMandatoryInputsAreFilled(formBlock))) {
                 this.logger.log("Address details - All mandatory inputs are filled");
                 ENGrid.setBodyData("hide-fast-address-details", "true");
             }

--- a/packages/common/dist/fast-form-fill.js
+++ b/packages/common/dist/fast-form-fill.js
@@ -26,7 +26,7 @@ export class FastFormFill {
     }
     run() {
         const fastPersonalDetailsFormBlocks = document.querySelectorAll(".en__component--formblock.fast-personal-details");
-        if (fastPersonalDetailsFormBlocks) {
+        if (fastPersonalDetailsFormBlocks.length > 0) {
             if ([...fastPersonalDetailsFormBlocks].every((formBlock) => FastFormFill.allMandatoryInputsAreFilled(formBlock))) {
                 this.logger.log("Personal details - All mandatory inputs are filled");
                 ENGrid.setBodyData("hide-fast-personal-details", "true");
@@ -37,7 +37,7 @@ export class FastFormFill {
             }
         }
         const fastAddressDetailsFormBlocks = document.querySelectorAll(".en__component--formblock.fast-address-details");
-        if (fastAddressDetailsFormBlocks) {
+        if (fastAddressDetailsFormBlocks.length > 0) {
             if ([...fastAddressDetailsFormBlocks].every((formBlock) => FastFormFill.allMandatoryInputsAreFilled(formBlock))) {
                 this.logger.log("Address details - All mandatory inputs are filled");
                 ENGrid.setBodyData("hide-fast-address-details", "true");

--- a/packages/common/src/fast-form-fill.ts
+++ b/packages/common/src/fast-form-fill.ts
@@ -33,13 +33,15 @@ export class FastFormFill {
   }
 
   private run() {
-    const fastPersonalDetailsFormBlock = document.querySelector(
+    const fastPersonalDetailsFormBlocks = document.querySelectorAll(
       ".en__component--formblock.fast-personal-details"
-    ) as HTMLElement;
+    ) as NodeListOf<HTMLElement>;
 
-    if (fastPersonalDetailsFormBlock) {
+    if (fastPersonalDetailsFormBlocks) {
       if (
-        FastFormFill.allMandatoryInputsAreFilled(fastPersonalDetailsFormBlock)
+        [...fastPersonalDetailsFormBlocks].every((formBlock) =>
+          FastFormFill.allMandatoryInputsAreFilled(formBlock)
+        )
       ) {
         this.logger.log("Personal details - All mandatory inputs are filled");
         ENGrid.setBodyData("hide-fast-personal-details", "true");
@@ -51,13 +53,15 @@ export class FastFormFill {
       }
     }
 
-    const fastAddressDetailsFormBlock = document.querySelector(
+    const fastAddressDetailsFormBlocks = document.querySelectorAll(
       ".en__component--formblock.fast-address-details"
-    ) as HTMLElement;
+    ) as NodeListOf<HTMLElement>;
 
-    if (fastAddressDetailsFormBlock) {
+    if (fastAddressDetailsFormBlocks) {
       if (
-        FastFormFill.allMandatoryInputsAreFilled(fastAddressDetailsFormBlock)
+        [...fastAddressDetailsFormBlocks].every((formBlock) =>
+          FastFormFill.allMandatoryInputsAreFilled(formBlock)
+        )
       ) {
         this.logger.log("Address details - All mandatory inputs are filled");
         ENGrid.setBodyData("hide-fast-address-details", "true");

--- a/packages/common/src/fast-form-fill.ts
+++ b/packages/common/src/fast-form-fill.ts
@@ -37,7 +37,7 @@ export class FastFormFill {
       ".en__component--formblock.fast-personal-details"
     ) as NodeListOf<HTMLElement>;
 
-    if (fastPersonalDetailsFormBlocks) {
+    if (fastPersonalDetailsFormBlocks.length > 0) {
       if (
         [...fastPersonalDetailsFormBlocks].every((formBlock) =>
           FastFormFill.allMandatoryInputsAreFilled(formBlock)
@@ -57,7 +57,7 @@ export class FastFormFill {
       ".en__component--formblock.fast-address-details"
     ) as NodeListOf<HTMLElement>;
 
-    if (fastAddressDetailsFormBlocks) {
+    if (fastAddressDetailsFormBlocks.length > 0) {
       if (
         [...fastAddressDetailsFormBlocks].every((formBlock) =>
           FastFormFill.allMandatoryInputsAreFilled(formBlock)


### PR DESCRIPTION
…form sections have all mandatory inputs filled

--

Adjust fast-form-fill so that if we have multiple form blocks with the custom classes "fast-personal-details" or "fast-address-details" then ALL of those blocks need to have their mandatory inputs filled for the "fast form" to be considered active, and thus activate the "Welcome Back" component

To test we can use these links:

Missing a required field (address1) but the welcome back component still activates - https://preserve.nature.org/page/148559/donate/1?supporter.emailAddress=michaelt@4sitestudios.com&supporter.firstName=Michael&supporter.lastName=Thomas&supporter.city=New%20York&supporter.postcode=10001&supporter.region=NY&supporter.country=US

With this patch, it no longer activates - https://preserve.nature.org/page/148559/donate/1?assets=welcome-back&supporter.emailAddress=michaelt@4sitestudios.com&supporter.firstName=Michael&supporter.lastName=Thomas&supporter.city=New%20York&supporter.postcode=10001&supporter.region=NY&supporter.country=US

Once we add in the required field it activates as expected - https://preserve.nature.org/page/148559/donate/1?assets=welcome-back&supporter.emailAddress=michaelt@4sitestudios.com&supporter.firstName=Michael&supporter.lastName=Thomas&supporter.city=New%20York&supporter.postcode=10001&supporter.region=NY&supporter.country=US&supporter.address1=20%20W%2034th%20Street