### PR TITLE
fix embedded ecard on digital wallets

### DIFF
--- a/packages/styles/dist/main.css
+++ b/packages/styles/dist/main.css
@@ -7308,7 +7308,7 @@ body[data-engrid-page-type=e-card][data-engrid-embedded-ecard=true] .en__ecardre
   display: none;
 }
 
-body:not([data-engrid-embedded-ecard-sent=true]) .showif-embedded-ecard-sent {
+body:not(#en__pagebuilder):not([data-engrid-debug]):not([data-engrid-embedded-ecard-sent=true]) .showif-embedded-ecard-sent {
   display: none;
 }
 

--- a/packages/styles/src/_engrid-embedded-ecard.scss
+++ b/packages/styles/src/_engrid-embedded-ecard.scss
@@ -42,7 +42,7 @@ body[data-engrid-page-type="e-card"][data-engrid-embedded-ecard="true"] {
   }
 }
 
-body:not([data-engrid-embedded-ecard-sent="true"]) {
+body:not(#en__pagebuilder):not([data-engrid-debug]):not([data-engrid-embedded-ecard-sent="true"]) {
   .showif-embedded-ecard-sent {
     display: none;
   }


### PR DESCRIPTION
I noticed this implementation did not work for digital wallet payments because the onsubmit handler is not triggered by EN.

I've adjusted it so it does not rely on that to work. Instead, the embedded page manages its own sessionStorage via input event handlers, and a second sessionStorage variable, set by the host page, handles whether or not to send the ecard. This way it does not need to submit handler.

test page using this branch: https://preserve.nature.org/page/146226/donate/1