### PR TITLE
allow embedded ecard to have multiple recipients

### DIFF
--- a/packages/common/dist/embedded-ecard.d.ts
+++ b/packages/common/dist/embedded-ecard.d.ts
@@ -2,6 +2,7 @@ export declare class EmbeddedEcard {
     private logger;
     private readonly options;
     private _form;
+    isSubmitting: boolean;
     constructor();
     private onHostPage;
     private onEmbeddedEcardPage;
@@ -9,6 +10,8 @@ export declare class EmbeddedEcard {
     private embedEcard;
     private createIframe;
     private addEventListeners;
+    private setEmbeddedEcardSessionData;
+    private getEcardRecipients;
     private setupEmbeddedPage;
     private submitEcard;
     private sendPostMessage;

--- a/packages/common/dist/embedded-ecard.js
+++ b/packages/common/dist/embedded-ecard.js
@@ -11,6 +11,7 @@ export class EmbeddedEcard {
         this.logger = new EngridLogger("Embedded Ecard", "#D95D39", "#0E1428", "📧");
         this.options = EmbeddedEcardOptionsDefaults;
         this._form = EnForm.getInstance();
+        this.isSubmitting = false;
         // For the page hosting the embedded ecard
         if (this.onHostPage()) {
             // Clean up session variables if the page is reloaded, and it isn't a submission failure
@@ -111,6 +112,57 @@ export class EmbeddedEcard {
             }
         });
     }
+    setEmbeddedEcardSessionData() {
+        let ecardVariant = document.querySelector("[name='friend.ecard']");
+        let ecardSendDate = document.querySelector("[name='ecard.schedule']");
+        let ecardMessage = document.querySelector("[name='transaction.comments']");
+        //add "chain" param to window.location.href if it doesnt have it
+        const pageUrl = new URL(window.location.href);
+        if (!pageUrl.searchParams.has("chain")) {
+            pageUrl.searchParams.append("chain", "");
+        }
+        const embeddedEcardData = {
+            pageUrl: pageUrl.href,
+            formData: {
+                ecardVariant: (ecardVariant === null || ecardVariant === void 0 ? void 0 : ecardVariant.value) || "",
+                ecardSendDate: (ecardSendDate === null || ecardSendDate === void 0 ? void 0 : ecardSendDate.value) || "",
+                ecardMessage: (ecardMessage === null || ecardMessage === void 0 ? void 0 : ecardMessage.value) || "",
+                recipients: this.getEcardRecipients(),
+            },
+        };
+        sessionStorage.setItem("engrid-embedded-ecard", JSON.stringify(embeddedEcardData));
+    }
+    getEcardRecipients() {
+        const recipients = [];
+        const addRecipientButton = document.querySelector(".en__ecarditems__addrecipient");
+        //Single recipient form where the "add recipient" button is hidden, and we use the recipient name and email fields
+        const isSingleRecipientForm = !addRecipientButton || addRecipientButton.offsetHeight === 0;
+        if (isSingleRecipientForm) {
+            // When it is a single recipient form, we only need to get the recipient name and email from the input fields
+            let recipientName = document.querySelector(".en__ecardrecipients__name > input");
+            let recipientEmail = document.querySelector(".en__ecardrecipients__email > input");
+            if (recipientName && recipientEmail) {
+                recipients.push({
+                    name: recipientName.value,
+                    email: recipientEmail.value,
+                });
+            }
+            return recipients;
+        }
+        // For multiple recipient forms, we need to get the recipient name and email from each recipient in the recipient list
+        const recipientList = document.querySelector(".en__ecardrecipients__list");
+        recipientList === null || recipientList === void 0 ? void 0 : recipientList.querySelectorAll(".en__ecardrecipients__recipient").forEach((el) => {
+            const recipientName = el.querySelector(".ecardrecipient__name");
+            const recipientEmail = el.querySelector(".ecardrecipient__email");
+            if (recipientName && recipientEmail) {
+                recipients.push({
+                    name: recipientName.value,
+                    email: recipientEmail.value,
+                });
+            }
+        });
+        return recipients;
+    }
     setupEmbeddedPage() {
         let ecardVariant = document.querySelector("[name='friend.ecard']");
         let ecardSendDate = document.querySelector("[name='ecard.schedule']");
@@ -125,23 +177,25 @@ export class EmbeddedEcard {
             recipientEmail,
         ].forEach((el) => {
             el.addEventListener("input", () => {
-                //add "chain" param to window.location.href if it doesnt have it
-                const pageUrl = new URL(window.location.href);
-                if (!pageUrl.searchParams.has("chain")) {
-                    pageUrl.searchParams.append("chain", "");
-                }
-                sessionStorage.setItem("engrid-embedded-ecard", JSON.stringify({
-                    pageUrl: pageUrl.href,
-                    formData: {
-                        ecardVariant: (ecardVariant === null || ecardVariant === void 0 ? void 0 : ecardVariant.value) || "",
-                        ecardSendDate: (ecardSendDate === null || ecardSendDate === void 0 ? void 0 : ecardSendDate.value) || "",
-                        ecardMessage: (ecardMessage === null || ecardMessage === void 0 ? void 0 : ecardMessage.value) || "",
-                        recipientName: (recipientName === null || recipientName === void 0 ? void 0 : recipientName.value) || "",
-                        recipientEmail: (recipientEmail === null || recipientEmail === void 0 ? void 0 : recipientEmail.value) || "",
-                    },
-                }));
+                if (this.isSubmitting)
+                    return;
+                this.setEmbeddedEcardSessionData();
             });
         });
+        // MutationObserver to detect changes in the recipient list and update the session data
+        const observer = new MutationObserver((mutationsList) => {
+            for (let mutation of mutationsList) {
+                if (mutation.type === "childList") {
+                    if (this.isSubmitting)
+                        return;
+                    this.setEmbeddedEcardSessionData();
+                }
+            }
+        });
+        const recipientList = document.querySelector(".en__ecardrecipients__list");
+        if (recipientList) {
+            observer.observe(recipientList, { childList: true });
+        }
         document.querySelectorAll(".en__ecarditems__thumb").forEach((el) => {
             // Making sure the session value is changed when this is clicked
             el.addEventListener("click", () => {
@@ -154,6 +208,7 @@ export class EmbeddedEcard {
             this.logger.log("Received post message", e.data);
             switch (e.data.action) {
                 case "submit_form":
+                    this.isSubmitting = true;
                     let embeddedEcardData = JSON.parse(sessionStorage.getItem("engrid-embedded-ecard") || "{}");
                     if (ecardVariant) {
                         ecardVariant.value = embeddedEcardData.formData["ecardVariant"];
@@ -164,10 +219,12 @@ export class EmbeddedEcard {
                     if (ecardMessage) {
                         ecardMessage.value = embeddedEcardData.formData["ecardMessage"];
                     }
-                    recipientName.value = embeddedEcardData.formData["recipientName"];
-                    recipientEmail.value = embeddedEcardData.formData["recipientEmail"];
                     const addRecipientButton = document.querySelector(".en__ecarditems__addrecipient");
-                    addRecipientButton === null || addRecipientButton === void 0 ? void 0 : addRecipientButton.click();
+                    embeddedEcardData.formData.recipients.forEach((recipient) => {
+                        recipientName.value = recipient.name;
+                        recipientEmail.value = recipient.email;
+                        addRecipientButton === null || addRecipientButton === void 0 ? void 0 : addRecipientButton.click();
+                    });
                     const form = EnForm.getInstance();
                     form.submitForm();
                     sessionStorage.removeItem("engrid-embedded-ecard");

--- a/packages/common/src/interfaces/global.d.ts
+++ b/packages/common/src/interfaces/global.d.ts
@@ -20,7 +20,7 @@ declare global {
     EngridExitIntent: ExitIntentOptions;
     EngridTranslate: TranslateOptions;
     EngridEcardToTarget: EcardToTargetOptions;
-    EngridEmbeddedEcard: EmbeddedEcardOptions
+    EngridEmbeddedEcard: EmbeddedEcardOptions;
     EngridVersion: string;
     EngridLoader: {
       "repo-name"?: string;


### PR DESCRIPTION
This patch adds an enhancement to the Embedded Ecard component to allow for Ecards to have multiple recipients. In the previous version, it was only intended to have 1 recipient, the "add recipient" button was hidden and the values from the inputs were taken as the recipient name+email.

In this new version, if the "add recipient" button is hidden, the old functionality will still work - allowing us to keep that streamlined form experienced.

But if the "add recipient" button is visible then recipients are taken from the "recipient list" element. This is done with a MutationObserver on that element so that the recipients are kept up to date when adding/removing them from the list.

Also introduced an "isSubmitting" flag to prevent some circular logic that re-set the session storage items in some conditions.. 🙃

Functionality can be tested on this page: https://protect.worldwildlife.org/page/71102/donate/1 it uses a build of WWF's theme with this branch.

To try it with a single recipient experience, go to the ecard page https://us.engagingnetworks.app/index.html#pages/71103/edit and uncomment the code in the "test single recipient code block"