### PR TITLE
feat: Add window option for body banner page bg

### DIFF
--- a/packages/scripts/dist/page-background.d.ts
+++ b/packages/scripts/dist/page-background.d.ts
@@ -1,3 +1,8 @@
+declare global {
+    interface Window {
+        UseBodyBannerImageAsBackground?: boolean;
+    }
+}
 export declare class PageBackground {
     private pageBackground;
     private bodyBanner;

--- a/packages/scripts/dist/page-background.js
+++ b/packages/scripts/dist/page-background.js
@@ -7,6 +7,9 @@ export class PageBackground {
         this.bodyBannerImage = null;
         this.mutationObserver = null;
         this.logger = new EngridLogger("PageBackground", "lightblue", "darkblue", "🖼️");
+        if (typeof window.UseBodyBannerImageAsBackground !== "undefined") {
+            useBodyBannerImage = !!window.UseBodyBannerImageAsBackground;
+        }
         if (useBodyBannerImage) {
             this.bodyBannerImage = this.findBodyBannerImage();
         }

--- a/packages/scripts/src/page-background.ts
+++ b/packages/scripts/src/page-background.ts
@@ -1,5 +1,11 @@
 import { ENGrid, EngridLogger } from ".";
 
+declare global {
+  interface Window {
+    UseBodyBannerImageAsBackground?: boolean;
+  }
+}
+
 export class PageBackground {
   // @TODO: Change page-backgroundImage to page-background
   private pageBackground: HTMLElement | null = document.querySelector(
@@ -18,6 +24,10 @@ export class PageBackground {
   );
 
   constructor(useBodyBannerImage: boolean = false) {
+    if (typeof window.UseBodyBannerImageAsBackground !== "undefined") {
+      useBodyBannerImage = !!window.UseBodyBannerImageAsBackground;
+    }
+
     if (useBodyBannerImage) {
       this.bodyBannerImage = this.findBodyBannerImage();
     }


### PR DESCRIPTION
Adds the ability to override the options.UseBodyBannerImageAsBackground on a per-page basis using window.UseBodyBannerImageAsBackground