### PR TITLE
Adds the option to set a label for remember me

### DIFF
--- a/packages/scripts/dist/interfaces/options.d.ts
+++ b/packages/scripts/dist/interfaces/options.d.ts
@@ -52,6 +52,7 @@ export interface Options {
         fieldClearSelectorTarget?: string;
         fieldClearSelectorTargetLocation?: string;
         fieldClearLabel?: string;
+        rememberMeLabel?: string;
         checked?: boolean;
         encryptData?: boolean;
         hide?: boolean;

--- a/packages/scripts/dist/remember-me.d.ts
+++ b/packages/scripts/dist/remember-me.d.ts
@@ -22,6 +22,7 @@ export declare class RememberMe {
     private fieldClearSelectorTarget;
     private fieldClearSelectorTargetLocation;
     private fieldClearLabel;
+    private rememberMeLabel;
     constructor(options: {
         remoteUrl?: string;
         cookieName?: string;
@@ -37,6 +38,7 @@ export declare class RememberMe {
         fieldClearSelectorTarget?: string;
         fieldClearSelectorTargetLocation?: string;
         fieldClearLabel?: string;
+        rememberMeLabel?: string;
         checked?: boolean;
         encryptData?: boolean;
         hide?: boolean;

--- a/packages/scripts/dist/remember-me.js
+++ b/packages/scripts/dist/remember-me.js
@@ -65,6 +65,9 @@ export class RememberMe {
         this.fieldClearLabel = options.fieldClearLabel
             ? options.fieldClearLabel
             : "(clear autofill)";
+        this.rememberMeLabel = options.rememberMeLabel
+            ? options.rememberMeLabel
+            : "Remember Me";
         this.fieldData = {};
         if (this.useRemote()) {
             this.createIframe(() => {
@@ -228,11 +231,11 @@ export class RememberMe {
     insertRememberMeOptin() {
         let rememberMeOptInField = document.getElementById("remember-me-opt-in");
         if (!rememberMeOptInField) {
-            const rememberMeLabel = "Remember Me";
+            const rememberMeLabel = this.rememberMeLabel;
             const rememberMeInfo = `
-				Check “Remember me” to complete forms on this device faster. 
+				Check “${rememberMeLabel}” to complete forms on this device faster. 
 				While your financial information won’t be stored, you should only check this box from a personal device. 
-				Click “Clear autofill” to remove the information from your device at any time.
+				Click “${this.fieldClearLabel}” to remove the information from your device at any time.
 			`;
             const rememberMeOptInFieldChecked = this.rememberMeOptIn ? "checked" : "";
             const rememberMeOptInField = document.createElement("div");

--- a/packages/scripts/src/interfaces/options.ts
+++ b/packages/scripts/src/interfaces/options.ts
@@ -56,6 +56,7 @@ export interface Options {
         fieldClearSelectorTarget?: string;
         fieldClearSelectorTargetLocation?: string;
         fieldClearLabel?: string;
+        rememberMeLabel?: string;
         checked?: boolean;
         encryptData?: boolean;
         hide?: boolean;

--- a/packages/scripts/src/remember-me.ts
+++ b/packages/scripts/src/remember-me.ts
@@ -36,6 +36,7 @@ export class RememberMe {
   private fieldClearSelectorTarget: string;
   private fieldClearSelectorTargetLocation: string;
   private fieldClearLabel: string;
+  private rememberMeLabel: string;
 
   constructor(options: {
     remoteUrl?: string;
@@ -52,6 +53,7 @@ export class RememberMe {
     fieldClearSelectorTarget?: string;
     fieldClearSelectorTargetLocation?: string;
     fieldClearLabel?: string;
+    rememberMeLabel?: string;
     checked?: boolean;
     encryptData?: boolean;
     hide?: boolean;
@@ -108,6 +110,10 @@ export class RememberMe {
     this.fieldClearLabel = options.fieldClearLabel
       ? options.fieldClearLabel
       : "(clear autofill)";
+
+    this.rememberMeLabel = options.rememberMeLabel
+      ? options.rememberMeLabel
+      : "Remember Me";
 
     this.fieldData = {};
     if (this.useRemote()) {
@@ -283,11 +289,11 @@ export class RememberMe {
       "remember-me-opt-in"
     ) as HTMLInputElement;
     if (!rememberMeOptInField) {
-      const rememberMeLabel = "Remember Me";
+      const rememberMeLabel = this.rememberMeLabel;
       const rememberMeInfo = `
-				Check “Remember me” to complete forms on this device faster. 
+				Check “${rememberMeLabel}” to complete forms on this device faster. 
 				While your financial information won’t be stored, you should only check this box from a personal device. 
-				Click “Clear autofill” to remove the information from your device at any time.
+				Click “${this.fieldClearLabel}” to remove the information from your device at any time.
 			`;
 
       const rememberMeOptInFieldChecked = this.rememberMeOptIn ? "checked" : "";


### PR DESCRIPTION
* Allows setting `rememberMeLabel` in RememberMe options
* Optional, defaults to "Remember Me" (Same behavior as before)
* Updates the tooltip copy to reflect the change in label
* Also updates the tooltip copy to reflect the change in the existing label option `fieldClearLabel`